### PR TITLE
Set return_dict=True and remove output_hidden_states in Transformer

### DIFF
--- a/custom_train.py
+++ b/custom_train.py
@@ -183,7 +183,7 @@ class Trainer:
                 model.module.resize_token_embeddings([self.model_config.ent_token, self.model_config.sep_token], 
                                 set_class_token_index = False,
                                 add_tokens_to_tokenizer=False)
-        optimizer = self.create_optimizer(model.model)
+        optimizer = self.create_optimizer(model.module if isinstance(model, DDP) else model)
 
         if self.compile_model:
             model.compile_for_training()

--- a/custom_train.py
+++ b/custom_train.py
@@ -194,7 +194,7 @@ class Trainer:
         # dataset = GLiNERDataset(dataset, config = self.config, data_processor=self.data_processor)
         # collator = DataCollatorWithPadding(self.config)
         collator = DataCollator(self.config, data_processor=data_processor, prepare_labels=True)
-        data_loader = DataLoader(dataset, batch_size=self.config.train_batch_size, num_workers=12,
+        data_loader = DataLoader(dataset, batch_size=self.config.train_batch_size, num_workers=2,
                                                         shuffle=shuffle, collate_fn=collator, sampler=sampler)
         return data_loader
     

--- a/custom_train.py
+++ b/custom_train.py
@@ -178,7 +178,7 @@ class Trainer:
                                     set_class_token_index = False,
                                     add_tokens_to_tokenizer=False)
         if rank is not None:
-            model = DDP(model, device_ids=[rank], output_device=rank, find_unused_parameters=False)
+            model = DDP(model, device_ids=[rank], output_device=rank, find_unused_parameters=True)
             if self.config.labels_encoder is None:
                 model.module.resize_token_embeddings([self.model_config.ent_token, self.model_config.sep_token], 
                                 set_class_token_index = False,

--- a/custom_train.py
+++ b/custom_train.py
@@ -208,7 +208,7 @@ class Trainer:
 
         sampler = DistributedSampler(dataset, num_replicas=world_size, rank=rank, shuffle=True, drop_last=False)
 
-        train_loader = self.create_dataloader(dataset, model.data_processor, sampler=sampler, shuffle=False)
+        train_loader = train_loader = self.create_dataloader(dataset, model.module.data_processor if isinstance(model, DDP) else model.data_processor, sampler=sampler, shuffle=False)
 
         num_steps = self.config.num_steps // world_size
 

--- a/custom_train.py
+++ b/custom_train.py
@@ -282,8 +282,8 @@ class Trainer:
                     x[k] = v.to(device)
             
             try:
-                with torch.cuda.amp.autocast(dtype=torch.float16):
-                    loss = model(alpha = self.config.loss_alpha,
+                # with torch.cuda.amp.autocast(dtype=torch.float16):
+                loss = model(alpha = self.config.loss_alpha,
                                     gamma = self.config.loss_gamma,
                                     label_smoothing = self.config.label_smoothing,
                                     reduction = self.config.loss_reduction,

--- a/gliner/modeling/encoder.py
+++ b/gliner/modeling/encoder.py
@@ -97,7 +97,7 @@ class Transformer(nn.Module):
             output_hidden_states = True
         else:
             output_hidden_states = False
-        output = self.model(*args, output_hidden_states = output_hidden_states, 
+        output = self.model(*args, #output_hidden_states = output_hidden_states, 
                                             return_dict = True,  **kwargs)
         if self.config.fuse_layers:
             encoder_layer = self.layers_fuser(output.hidden_states)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Stop passing the output_hidden_states flag into the wrapped model call in the encoder, relying on the model's default behavior instead.