### PR TITLE
Research: Critical analysis of ptbr config/training against deep research report

### DIFF
--- a/research/gliner_config.md
+++ b/research/gliner_config.md
@@ -1,0 +1,33 @@
+# Research Topic: GLiNER Model Configuration
+
+## Source: deep-research-report.md (sections on GLiNER config, architecture routing)
+
+### Key Findings from Report
+
+**GLiNER config fields (belong under `model:`):**
+- Backbone: `model_name`, `fine_tune`
+- Architecture routing: `span_mode`, `labels_encoder`, `labels_decoder`, `relations_layer`, `triples_layer`
+- Prompt/special tokens: `ent_token`, `sep_token`, `rel_token`, embedding toggles, token indices
+- Sequence/spans: `max_len`, `max_width`, `represent_spans`, `neg_spans_ratio`
+- Open label-set: `max_types`, `max_neg_type_ratio`
+- Representation: `subtoken_pooling`, `words_splitter_type`, head sizes, dropout, fusion knobs
+- Multitask coefficients: `token_loss_coef`, `span_loss_coef`, decoder/adjacency/relation loss coefs
+- Optional snapshots: `encoder_config`, `labels_encoder_config`, `labels_decoder_config`
+
+**Core principle: GLiNER config affects architecture, inference, preprocessing**
+- These get serialized as `gliner_config.json` via `save_pretrained`
+- They should be set BEFORE training
+
+**Validation rules the report recommends:**
+- If parameter changes how inputs are tokenized/spans enumerated/prompts constructed/label spaces sampled -> GLiNER config
+- span_mode standardize on `token_level` (not `token-level`)
+- Backbone config snapshot is read-only unless building new backbone
+
+### Analysis Task
+
+Critically compare our `config_cli.py` `_GLINER_RULES` and `training_cli.py` `_FIELD_SCHEMA` model section against the report. Document:
+1. Coverage of all recommended GLiNER config fields
+2. Whether our validation rules (ranges, literals) match the report's recommendations
+3. Whether the config_cli and training_cli model sections are consistent with each other
+4. Whether cross-field validation (method-specific requirements) is complete
+5. Any fields in the report that we're missing or handling incorrectly

--- a/research/gliner_config_report.md
+++ b/research/gliner_config_report.md
@@ -1,0 +1,423 @@
+## GLiNER Model Configuration Report
+
+### Executive Summary
+
+The toolkit has two independent validation paths for model fields -- `config_cli.py` (expects `gliner_config:` YAML section) and `training_cli.py` (expects `model:` YAML section) -- that are structurally incompatible, use different validation engines, and diverge on field coverage, required-vs-optional designations, literal allowed-value sets, and cross-field semantic checks. Upstream `gliner/config.py` exposes fields across five config subclasses that are only partially covered: `labels_encoder_config`, `labels_decoder_config`, and several decoder/relex constructor parameters are missing from one or both validators. A critical upstream bug exists where `GLiNERConfig.model_type` checks for `"token-level"` (hyphen) while the typed config subclasses and our validators all use `"token_level"` (underscore), creating a silent architecture-routing mismatch.
+
+---
+
+### config_cli.py vs training_cli.py Consistency
+
+These two files validate the **same conceptual model fields** but disagree on YAML structure, field schemas, required/optional status, allowed values, and cross-field logic. A config YAML valid for one will **fail** for the other.
+
+#### 1. YAML Section Name Mismatch
+
+| Aspect | config_cli.py | training_cli.py |
+|--------|--------------|-----------------|
+| Section key | `gliner_config:` | `model:` |
+| Error prefix | `gliner_config.field_name` | `model.field_name` |
+
+A user writing a YAML with `model:` (as the template.yaml does) will get an immediate `"Missing 'gliner_config' section"` error from `config_cli.py`. Conversely, a YAML with `gliner_config:` will cause `training_cli.py` to emit DEFAULT warnings for every model field and then fail on the required ones (`model.model_name`, `model.span_mode`, `model.max_len`).
+
+#### 2. Required Field Disagreements
+
+| Field | config_cli.py | training_cli.py |
+|-------|--------------|-----------------|
+| `model_name` | required | required |
+| `span_mode` | **optional** (default `"markerV0"`) | **required** (no default) |
+| `max_len` | **optional** (default `384`) | **required** (no default) |
+
+`config_cli.py` treats `span_mode` and `max_len` as optional with defaults. `training_cli.py` marks both as `True` (required), meaning they must be explicitly provided. This means a minimal config that works with `config_cli.py` will fail validation in `training_cli.py`.
+
+#### 3. Allowed Literal Sets for `span_mode`
+
+| Validator | Allowed values |
+|-----------|---------------|
+| `config_cli.py` line 49-53 | `{"markerV0", "markerV1", "marker", "query", "mlp", "cat", "conv_conv", "conv_max", "conv_mean", "conv_sum", "conv_share", "token_level"}` (12 values) |
+| `training_cli.py` line 455 | `{"markerV0", "token_level"}` (2 values) |
+
+`training_cli.py` will **reject** legitimate upstream span modes like `"markerV1"`, `"marker"`, `"query"`, `"mlp"`, `"cat"`, and all `conv_*` variants. This is a significant over-restriction.
+
+#### 4. Allowed Literal Sets for `subtoken_pooling`
+
+| Validator | Allowed values |
+|-----------|---------------|
+| `config_cli.py` line 75 | `{"first", "mean", "max"}` |
+| `training_cli.py` line 464 | `{"first", "mean"}` |
+
+`config_cli.py` allows `"max"` but `training_cli.py` does not.
+
+#### 5. Missing Fields in config_cli.py
+
+`config_cli.py` does **not** validate:
+- `encoder_config` (present in `training_cli.py` at line 137)
+
+#### 6. Missing Fields in training_cli.py
+
+`training_cli.py` does **not** have explicit range constraints on model fields. It only does type checks and enum checks. For example:
+- No range check on `max_width` (config_cli checks `[1, 128]`)
+- No range check on `hidden_size` (config_cli checks `[64, 4096]`)
+- No range check on `max_len` (config_cli checks `[32, 8192]`)
+- No range check on `max_types` (config_cli checks `[1, 1000]`)
+- No range check on `max_neg_type_ratio` (config_cli checks `[0, 100]`)
+- No range check on `num_post_fusion_layers` (config_cli checks `[1, 12]`)
+- No range check on `num_rnn_layers` (config_cli checks `[0, 4]`)
+- No range check on `rel_token_index` (config_cli checks `[-1, 100000]`)
+- No range check on `class_token_index` (config_cli checks `[-1, 100000]`)
+- No range check on `vocab_size` (config_cli checks `[-1, 1000000]`)
+
+The `training_cli.py` does have bounded numeric checks for `model.dropout` and `model.blank_entity_prob` in `semantic_checks()` (line 537-548), but these are a small subset.
+
+#### 7. Cross-Field Validation Differences
+
+| Check | config_cli.py | training_cli.py |
+|-------|--------------|-----------------|
+| BiEncoder requires `labels_encoder` | Yes (line 303-307) | No |
+| Decoder requires `labels_decoder` | Yes (line 309-313) | No |
+| Relex requires `relations_layer` | Yes (line 315-319) | No |
+| `span_mode` vs method consistency | Yes (line 323-335) | No (no method concept) |
+| Decoder fields without `labels_decoder` | Yes (line 338-351) | Partial (warns if `decoder_mode` missing when `labels_decoder` set, line 500-506) |
+| Relex fields without `relations_layer` | Yes (line 353-369) | No |
+| `bf16`/`fp16` mutual exclusion | No | Yes (line 553-558) |
+| WandB project required when `report_to=wandb` | No | Yes (line 508-515) |
+| Hub model id required when `push_to_hub` | No | Yes (line 517-523) |
+
+`config_cli.py` has method-aware cross-field checks (it takes a `method` parameter). `training_cli.py` has no concept of a "method" at all and cannot perform these checks. However, `training_cli.py` has training-specific cross-field checks that `config_cli.py` lacks.
+
+#### 8. Validation Engine Architecture
+
+- `config_cli.py`: Rule-based tuples with `(key, type, required, default, constraint)`. Validates a flat dict. Produces `ValidationReport` with structured issues.
+- `training_cli.py`: Schema-based tuples with `(dotted_key, type, required, default, description)`. Validates a nested dict via `_deep_get`/`_deep_set`. Produces `ValidationResult` with string-based issues.
+
+These are entirely separate codebases with no shared logic.
+
+#### 9. Default Value Disagreements
+
+| Field | config_cli.py default | training_cli.py default |
+|-------|----------------------|------------------------|
+| `decoder_mode` | `"span"` | `None` |
+| `post_fusion_schema` | `""` | `""` |
+
+For `decoder_mode`: `config_cli.py` (line 59) defaults to `"span"`, while `training_cli.py` (line 104) defaults to `None`. This means if a user omits `decoder_mode`, `config_cli.py` will inject `"span"` into the config, but `training_cli.py` will leave it as `None`. This changes downstream behavior.
+
+#### 10. LoRA Section Differences
+
+| Aspect | config_cli.py | training_cli.py |
+|--------|--------------|-----------------|
+| Section key | `lora_config:` | `lora:` |
+| Activation | `--full-or-lora lora` CLI flag | `lora.enabled: true` field |
+| Default `lora_dropout` | `0.1` | `0.05` |
+| Default `target_modules` | `["query_proj", "value_proj"]` | `["q_proj", "v_proj"]` |
+| Default `task_type` | `"FEATURE_EXTRACTION"` | `"TOKEN_CLS"` |
+| Extra fields | `fan_in_fan_out`, `use_rslora`, `init_lora_weights` | None of these |
+| Missing fields | No `enabled` toggle | Has `enabled` toggle |
+
+---
+
+### Coverage vs GLiNER Config Classes
+
+#### BaseGLiNERConfig (28 explicit parameters)
+
+| Parameter | config_cli.py | training_cli.py | Notes |
+|-----------|:---:|:---:|-------|
+| `model_name` | Yes | Yes | |
+| `name` | Yes | Yes | |
+| `max_width` | Yes | Yes | |
+| `hidden_size` | Yes | Yes | |
+| `dropout` | Yes | Yes | |
+| `fine_tune` | Yes | Yes | |
+| `subtoken_pooling` | Yes | Yes | |
+| `span_mode` | Yes | Yes | |
+| `post_fusion_schema` | Yes | Yes | |
+| `num_post_fusion_layers` | Yes | Yes | |
+| `vocab_size` | Yes | Yes | |
+| `max_neg_type_ratio` | Yes | Yes | |
+| `max_types` | Yes | Yes | |
+| `max_len` | Yes | Yes | |
+| `words_splitter_type` | Yes | Yes | |
+| `num_rnn_layers` | Yes | Yes | |
+| `fuse_layers` | Yes | Yes | |
+| `embed_ent_token` | Yes | Yes | |
+| `class_token_index` | Yes | Yes | |
+| `encoder_config` | **NO** | Yes | config_cli.py completely ignores this |
+| `ent_token` | Yes | Yes | |
+| `sep_token` | Yes | Yes | |
+| `_attn_implementation` | Yes | Yes | |
+| `token_loss_coef` | Yes | Yes | |
+| `span_loss_coef` | Yes | Yes | |
+| `represent_spans` | Yes | Yes | |
+| `neg_spans_ratio` | Yes | Yes | |
+
+Coverage: config_cli.py covers 27/28; training_cli.py covers 28/28.
+
+#### BiEncoderConfig (adds 2 parameters)
+
+| Parameter | config_cli.py | training_cli.py | Notes |
+|-----------|:---:|:---:|-------|
+| `labels_encoder` | Yes | Yes | |
+| `labels_encoder_config` | **NO** | **NO** | Missing from both validators |
+
+Coverage: Both cover 1/2 BiEncoder-specific parameters.
+
+#### UniEncoderSpanDecoderConfig (adds 6 parameters)
+
+| Parameter | config_cli.py | training_cli.py | Notes |
+|-----------|:---:|:---:|-------|
+| `labels_decoder` | Yes | Yes | |
+| `decoder_mode` | Yes | Yes | |
+| `full_decoder_context` | Yes | Yes | |
+| `blank_entity_prob` | Yes | Yes | |
+| `labels_decoder_config` | **NO** | **NO** | Missing from both validators |
+| `decoder_loss_coef` | Yes | Yes | |
+
+Coverage: Both cover 5/6 Decoder-specific parameters.
+
+#### UniEncoderRelexConfig (adds 7 parameters)
+
+| Parameter | config_cli.py | training_cli.py | Notes |
+|-----------|:---:|:---:|-------|
+| `relations_layer` | Yes | Yes | |
+| `triples_layer` | Yes | Yes | |
+| `embed_rel_token` | Yes | Yes | |
+| `rel_token_index` | Yes | Yes | |
+| `rel_token` | Yes | Yes | |
+| `adjacency_loss_coef` | Yes | Yes | |
+| `relation_loss_coef` | Yes | Yes | |
+
+Coverage: Both cover 7/7 Relex-specific parameters.
+
+#### GLiNERConfig (legacy auto-detect class, adds 3 explicit parameters)
+
+| Parameter | config_cli.py | training_cli.py | Notes |
+|-----------|:---:|:---:|-------|
+| `labels_encoder` | Yes | Yes | |
+| `labels_decoder` | Yes | Yes | |
+| `relations_layer` | Yes | Yes | |
+
+Coverage: Both cover 3/3 GLiNERConfig-specific parameters.
+
+**Key gap**: `labels_encoder_config` and `labels_decoder_config` are accepted by the upstream config classes but validated by neither of our tools.
+
+---
+
+### Validation Rules Accuracy
+
+#### Defaults vs Upstream
+
+All defaults in both validators were compared against `BaseGLiNERConfig.__init__` defaults (lines 13-42 of `gliner/config.py`):
+
+| Field | Upstream default | config_cli.py | training_cli.py | Match? |
+|-------|-----------------|--------------|-----------------|--------|
+| `model_name` | `"microsoft/deberta-v3-small"` | required (no default) | required (no default) | OK (required is stricter) |
+| `name` | `"gliner"` | `"gliner"` | `"gliner"` | Yes |
+| `max_width` | `12` | `12` | `12` | Yes |
+| `hidden_size` | `512` | `512` | `512` | Yes |
+| `dropout` | `0.4` | `0.4` | `0.4` | Yes |
+| `fine_tune` | `True` | `True` | `True` | Yes |
+| `subtoken_pooling` | `"first"` | `"first"` | `"first"` | Yes |
+| `span_mode` | `"markerV0"` | `"markerV0"` | required | config_cli matches; training_cli deviates |
+| `post_fusion_schema` | `""` | `""` | `""` | Yes |
+| `num_post_fusion_layers` | `1` | `1` | `1` | Yes |
+| `vocab_size` | `-1` | `-1` | `-1` | Yes |
+| `max_neg_type_ratio` | `1` | `1` | `1` | Yes |
+| `max_types` | `25` | `25` | `25` | Yes |
+| `max_len` | `384` | `384` | required | config_cli matches; training_cli deviates |
+| `words_splitter_type` | `"whitespace"` | `"whitespace"` | `"whitespace"` | Yes |
+| `num_rnn_layers` | `1` | `1` | `1` | Yes |
+| `fuse_layers` | `False` | `False` | `False` | Yes |
+| `embed_ent_token` | `True` | `True` | `True` | Yes |
+| `class_token_index` | `-1` | `-1` | `-1` | Yes |
+| `encoder_config` | `None` | not validated | `None` | N/A / Yes |
+| `ent_token` | `"<<ENT>>"` | `"<<ENT>>"` | `"<<ENT>>"` | Yes |
+| `sep_token` | `"<<SEP>>"` | `"<<SEP>>"` | `"<<SEP>>"` | Yes |
+| `_attn_implementation` | `None` | `None` | `None` | Yes |
+| `token_loss_coef` | `1.0` | `1.0` | `1.0` | Yes |
+| `span_loss_coef` | `1.0` | `1.0` | `1.0` | Yes |
+| `represent_spans` | `False` | `False` | `False` | Yes |
+| `neg_spans_ratio` | `1.0` | `1.0` | `1.0` | Yes |
+| `blank_entity_prob` | `0.1` | `0.1` | `0.1` | Yes |
+| `decoder_loss_coef` | `0.5` | `0.5` | `0.5` | Yes |
+| `decoder_mode` | `None` | **`"span"`** | `None` | **config_cli.py WRONG** -- upstream default is `None` |
+| `full_decoder_context` | `True` | `True` | `True` | Yes |
+| `adjacency_loss_coef` | `1.0` | `1.0` | `1.0` | Yes |
+| `relation_loss_coef` | `1.0` | `1.0` | `1.0` | Yes |
+
+**Bug found**: `config_cli.py` line 59 sets `decoder_mode` default to `"span"`, but upstream `UniEncoderSpanDecoderConfig.__init__` (line 146) defaults to `None`. This means `config_cli.py` will inject `decoder_mode="span"` into configs that never intended to set it, which could silently alter model behavior if `labels_decoder` is also set.
+
+#### Range Constraints Analysis
+
+`config_cli.py` defines range constraints. Are they reasonable?
+
+| Field | config_cli range | Assessment |
+|-------|-----------------|------------|
+| `max_width` | `[1, 128]` | Reasonable. Upstream default is 12. |
+| `hidden_size` | `[64, 4096]` | Reasonable for projection sizes. |
+| `dropout` | `[0.0, 0.9]` | OK. training_cli.py uses `[0.0, 1.0]` -- the stricter 0.9 upper bound is arguably better. |
+| `max_len` | `[32, 8192]` | Good, accommodates modern long-context models. |
+| `max_types` | `[1, 1000]` | Reasonable. |
+| `max_neg_type_ratio` | `[0, 100]` | Reasonable. |
+| `num_post_fusion_layers` | `[1, 12]` | Reasonable. |
+| `num_rnn_layers` | `[0, 4]` | Reasonable. |
+| `blank_entity_prob` | `[0.0, 1.0]` | Correct (probability). |
+| `decoder_loss_coef` | `[0.0, 10.0]` | Reasonable. |
+| `adjacency_loss_coef` | `[0.0, 10.0]` | Reasonable. |
+| `relation_loss_coef` | `[0.0, 10.0]` | Reasonable. |
+| `token_loss_coef` | `[0.0, 10.0]` | Reasonable. |
+| `span_loss_coef` | `[0.0, 10.0]` | Reasonable. |
+| `neg_spans_ratio` | `[0.0, 10.0]` | Reasonable. |
+
+---
+
+### Cross-Field Validation Completeness
+
+#### What config_cli.py checks (lines 289-369)
+
+1. **BiEncoder requires `labels_encoder`**: Yes (line 303-307).
+2. **Decoder requires `labels_decoder`**: Yes (line 309-313).
+3. **Relex requires `relations_layer`**: Yes (line 315-319).
+4. **`span_mode` vs method consistency**: Yes (lines 323-335). Forces `token_level` for token method; warns for other methods using `token_level`.
+5. **Decoder fields when method is not decoder**: Yes (lines 338-351). Warns about orphaned decoder fields.
+6. **Relex fields when method is not relex**: Yes (lines 353-369). Warns about orphaned relex fields.
+
+#### What config_cli.py MISSES
+
+1. **`represent_spans` must be `True` for `UniEncoderTokenDecoderConfig`**: Upstream `UniEncoderTokenDecoderConfig.__init__` (line 187) hardcodes `self.represent_spans = True`. Our validator does not enforce this constraint.
+2. **`span_mode` incompatibility with span configs**: `UniEncoderSpanConfig` (line 125-126), `UniEncoderSpanRelexConfig` (line 236-237), and `BiEncoderSpanConfig` (line 276-277) all raise `ValueError` if `span_mode == "token_level"`. Our cross-field validation warns but does not error.
+3. **`triples_layer` depends on `relations_layer`**: Partially checked (lines 361-369 warn if `triples_layer` set without `relations_layer`), but only when method is not relex.
+4. **No check that `labels_decoder` is not None when decoder-specific fields are used**: The check at lines 338-351 only warns; it should arguably error.
+5. **No check for `labels_encoder_config` consistency with `labels_encoder`**: If `labels_encoder` is set, `labels_encoder_config` might be needed.
+
+#### What training_cli.py checks (lines 469-560)
+
+1. **Enum validation for model fields**: `span_mode`, `subtoken_pooling`, `_attn_implementation` (lines 485-497).
+2. **Decoder fields require `labels_decoder`**: Partial (lines 500-506). Only checks that `decoder_mode` should be set when `labels_decoder` is used.
+3. **WandB/Hub integration checks**: Yes (lines 508-523).
+4. **Positive numeric checks**: Yes (lines 526-535).
+5. **Bounded numeric checks**: Yes (lines 537-548).
+6. **bf16/fp16 mutual exclusion**: Yes (lines 553-558).
+
+#### What training_cli.py MISSES
+
+1. **No method-aware validation at all**: No concept of biencoder/decoder/relex/span/token methods.
+2. **No check that BiEncoder requires `labels_encoder`**.
+3. **No check that Relex requires `relations_layer`**.
+4. **No `span_mode` vs architecture consistency checks**.
+5. **No orphaned decoder/relex field warnings**.
+6. **No check for `decoder_mode` allowed values** (it does not have `_VALID_DECODER_MODES`).
+7. **No check for `words_splitter_type` allowed values** (config_cli has 7 allowed splitters; training_cli has none).
+
+---
+
+### Missing Fields
+
+#### Fields in upstream `gliner/config.py` NOT validated by either tool
+
+| Field | Source class | Why it matters |
+|-------|-------------|---------------|
+| `labels_encoder_config` | `BiEncoderConfig` (line 252) | Snapshot of the labels encoder's PretrainedConfig. Needed for reproducibility and Hub serialization. |
+| `labels_decoder_config` | `UniEncoderSpanDecoderConfig` (line 149) | Snapshot of the decoder's PretrainedConfig. Needed for reproducibility and Hub serialization. |
+
+#### Fields recommended by the research report NOT validated by either tool
+
+| Field | Report section | Status |
+|-------|---------------|--------|
+| `labels_encoder_config` | "Optional snapshots" | Missing from both |
+| `labels_decoder_config` | "Optional snapshots" | Missing from both |
+| `data_seed` | Research report YAML | Not in either validator (training_cli has `run.seed` only) |
+
+#### Fields in config_cli.py NOT in training_cli.py
+
+None -- `training_cli.py` covers all fields that `config_cli.py` covers, plus `encoder_config`.
+
+#### Fields in training_cli.py NOT in config_cli.py
+
+| Field | Notes |
+|-------|-------|
+| `encoder_config` | training_cli line 137 validates this; config_cli does not |
+
+---
+
+### Bug: span_mode "token-level" vs "token_level"
+
+This is a critical inconsistency in the upstream codebase itself, and our validators inherit it partially.
+
+#### The Upstream Bug
+
+In `gliner/config.py`, there are **two different string conventions** for token-level span mode:
+
+1. **Typed config subclasses use underscore `"token_level"`**:
+   - `UniEncoderSpanConfig.__init__` (line 125): `if self.span_mode == "token_level": raise ValueError`
+   - `UniEncoderTokenConfig.__init__` (line 136): `self.span_mode = "token_level"`
+   - `UniEncoderTokenDecoderConfig.__init__` (line 185): `self.span_mode = "token_level"`
+   - `UniEncoderSpanRelexConfig.__init__` (line 236): `if self.span_mode == "token_level": raise ValueError`
+   - `UniEncoderTokenRelexConfig.__init__` (line 246): `self.span_mode = "token_level"`
+   - `BiEncoderSpanConfig.__init__` (line 276): `if self.span_mode == "token_level": raise ValueError`
+   - `BiEncoderTokenConfig.__init__` (line 286): `self.span_mode = "token_level"`
+
+2. **The legacy `GLiNERConfig.model_type` property uses hyphen `"token-level"`**:
+   - Line 327: `if self.span_mode == "token-level":`
+   - Line 332: `if self.span_mode != "token-level"`
+   - Line 334: `if self.span_mode == "token-level":`
+   - Line 338: `elif self.span_mode == "token-level":`
+
+#### The Consequence
+
+If a user instantiates `GLiNERConfig(span_mode="token_level")`, the `model_type` property (lines 323-341) will **never match the `"token-level"` checks** and will fall through to return `"gliner_uni_encoder_span"` instead of `"gliner_uni_encoder_token"`. This means:
+
+- `GLiNERConfig(span_mode="token_level")` -> model_type = `"gliner_uni_encoder_span"` (**WRONG**: should be `"gliner_uni_encoder_token"`)
+- `GLiNERConfig(span_mode="token-level")` -> model_type = `"gliner_uni_encoder_token"` (**CORRECT** per the property, but inconsistent with all typed subclasses)
+
+This is a **silent architecture misrouting bug** in the upstream code. The typed subclasses enforce `"token_level"` (underscore), but the legacy auto-detect class requires `"token-level"` (hyphen) to route correctly.
+
+#### Our Validators
+
+Both `config_cli.py` and `training_cli.py` standardize on `"token_level"` (underscore), which is consistent with the typed config subclasses and the research report recommendation. However:
+
+- `config_cli.py` builds a `GLiNERConfig` object (line 376: `GLiNERConfig(**gliner_data)`), which uses the **legacy auto-detect** `model_type` property. If the user sets `span_mode="token_level"`, the resulting `GLiNERConfig` object will have the wrong `model_type`.
+- `training_cli.py` passes the model config dict to `GLiNER.from_config(model_cfg)` (line 1052), which internally may use `GLiNERConfig` or a typed subclass depending on the `from_config` implementation.
+
+**Neither validator warns the user about this upstream inconsistency.**
+
+---
+
+### Concrete Recommendations
+
+1. **Unify YAML section naming** (`config_cli.py` line 417, `training_cli.py` line 99-139): Choose one section name. The template.yaml uses `model:`, so `config_cli.py` should be updated to look for `model:` instead of `gliner_config:`. Alternatively, support both with a deprecation warning.
+
+2. **Unify required/optional status for `span_mode` and `max_len`** (`config_cli.py` lines 49, 80 vs `training_cli.py` lines 115, 127): Either both should be required or both should have defaults. Recommendation: make them optional with the upstream defaults (`"markerV0"` and `384`), as the upstream `BaseGLiNERConfig` has defaults for both.
+
+3. **Fix `decoder_mode` default in `config_cli.py`** (line 59): Change from `"span"` to `None` to match upstream `UniEncoderSpanDecoderConfig.__init__` (line 146 of `gliner/config.py`).
+
+4. **Harmonize `span_mode` allowed values** (`training_cli.py` line 455): Expand `_VALID_SPAN_MODES` to include all values from `config_cli.py` (line 49-53): `{"markerV0", "markerV1", "marker", "query", "mlp", "cat", "conv_conv", "conv_max", "conv_mean", "conv_sum", "conv_share", "token_level"}`.
+
+5. **Harmonize `subtoken_pooling` allowed values** (`training_cli.py` line 464): Add `"max"` to `_VALID_SUBTOKEN_POOLING` to match `config_cli.py` (line 75).
+
+6. **Add `labels_encoder_config` validation to both files**: Add a rule in `config_cli.py` after line 56 and a schema entry in `training_cli.py` after line 102: `("model.labels_encoder_config", (dict, type(None)), False, None, "Labels encoder config snapshot")`.
+
+7. **Add `labels_decoder_config` validation to both files**: Add a rule in `config_cli.py` after line 61 and a schema entry in `training_cli.py` after line 103: `("model.labels_decoder_config", (dict, type(None)), False, None, "Labels decoder config snapshot")`.
+
+8. **Add `encoder_config` to `config_cli.py`** (missing entirely): Add a rule like `("encoder_config", dict, False, None, None)` to `_GLINER_RULES` around line 100, accepting `dict` or `None`.
+
+9. **Add method-aware validation to `training_cli.py`**: The `semantic_checks()` function (line 469) should accept a method parameter or infer method from the config (e.g., presence of `labels_encoder`, `labels_decoder`, `relations_layer`) and perform the same cross-field checks as `config_cli.py` lines 289-369.
+
+10. **Add range constraints to `training_cli.py`**: Port the range checks from `config_cli.py` into `training_cli.py`'s `semantic_checks()` function for at least: `max_width`, `hidden_size`, `max_len`, `max_types`, `max_neg_type_ratio`, `num_post_fusion_layers`, `num_rnn_layers`.
+
+11. **Add `words_splitter_type` enum check to `training_cli.py`**: Add to `semantic_checks()` a `_check_enum` call for `model.words_splitter_type` with the set `{"whitespace", "spacy", "stanza", "mecab", "jieba", "janome", "camel"}`.
+
+12. **Add `decoder_mode` enum check to `training_cli.py`**: When `model.labels_decoder` is not None, validate `model.decoder_mode` against `{"span", "prompt"}`.
+
+13. **Fix the upstream `"token-level"` vs `"token_level"` bug**: In `gliner/config.py` lines 327, 332, 334, 338: replace all occurrences of `"token-level"` with `"token_level"`. This is a bug fix in the upstream code. Until this is fixed, `config_cli.py` should NOT use `GLiNERConfig(...)` directly (line 376) for token-level configs; it should instead use the typed subclass (e.g., `UniEncoderTokenConfig`).
+
+14. **Add a `represent_spans` cross-field check**: When `span_mode == "token_level"` and `labels_decoder` is set (i.e., `UniEncoderTokenDecoderConfig` scenario), enforce or warn that `represent_spans` should be `True`, per upstream line 187.
+
+15. **Unify LoRA section naming and defaults** (`config_cli.py` line 103-116 vs `training_cli.py` line 184-191):
+    - Section: `lora_config:` vs `lora:` -- pick one.
+    - `lora_dropout`: `0.1` vs `0.05` -- align to one value (the research report suggests `0.05`).
+    - `target_modules`: `["query_proj", "value_proj"]` vs `["q_proj", "v_proj"]` -- these are model-dependent; document this clearly and consider making it required rather than defaulted.
+    - `task_type`: `"FEATURE_EXTRACTION"` vs `"TOKEN_CLS"` -- the training_cli uses `TOKEN_CLS` which is more appropriate for token-level NER; update config_cli.
+
+16. **Extract shared validation logic**: Both validators duplicate substantial model-field logic. Extract a shared module (e.g., `ptbr/model_schema.py`) that defines the canonical field schema, type constraints, range constraints, allowed literals, and cross-field rules. Both `config_cli.py` and `training_cli.py` should import from this shared module.
+
+17. **Add `_VALID_DECODER_MODES` to `training_cli.py`** semantic checks: After line 497, add validation that when `model.decoder_mode` is not None, it must be one of `{"span", "prompt"}`.
+
+18. **Update template.yaml**: The template at `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/template.yaml` uses `model:` (compatible with `training_cli.py`), but is not compatible with `config_cli.py` which expects `gliner_config:`. After fixing recommendation 1, ensure the template works with both tools.

--- a/research/integration.md
+++ b/research/integration.md
@@ -1,0 +1,52 @@
+# Research Topic: Integration and End-to-End Architecture
+
+## Source: deep-research-report.md (sections on canonical YAML, routing, implementation conventions)
+
+### Key Findings from Report
+
+**Canonical YAML structure recommended:**
+```
+experiment:    -> script-level metadata
+model:         -> GLiNER config (serialized to gliner_config.json)
+peft:          -> LoRA config (training strategy)
+data:          -> script-level dataset paths + schema + preprocessing
+training:      -> HF TrainingArguments + GLiNER extensions
+logging:       -> W&B / extra logging controls
+```
+
+**Our actual YAML structure (template.yaml):**
+```
+run:           -> metadata
+model:         -> GLiNER config
+data:          -> dataset paths
+training:      -> training parameters
+lora:          -> LoRA config
+environment:   -> Hub, W&B, hardware
+```
+
+**Key integration points:**
+- config_cli.py expects `gliner_config:` and `lora_config:` sections
+- training_cli.py expects `run:`, `model:`, `data:`, `training:`, `lora:`, `environment:` sections
+- __main__.py routes to both but they have DIFFERENT YAML structures
+
+**Report recommendations on what train.py should forward:**
+- Hub upload args not currently forwarded
+- W&B run naming not forwarded
+- `label_smoothing` not forwarded
+- `remove_unused_columns: false` often essential
+
+**Data section report recommends but we don't have:**
+- Document schema fields (tokens, ner, relations)
+- Long document chunking configuration
+- preprocessing section
+
+### Analysis Task
+
+Critically compare the end-to-end integration of our system against the report. Document:
+1. Whether config_cli.py and training_cli.py use COMPATIBLE YAML structures (they currently don't!)
+2. Whether the canonical YAML structure from the report is achievable with our current code
+3. Whether __main__.py correctly routes between the two CLIs
+4. Missing data preprocessing features (chunking, schema validation)
+5. Whether the parameter flow diagram from the report matches our implementation
+6. Whether `train.py` (upstream GLiNER) forwards all the parameters our CLI validates
+7. Concrete recommendations to unify the config format between config_cli and training_cli

--- a/research/integration_report.md
+++ b/research/integration_report.md
@@ -1,0 +1,297 @@
+## Integration and End-to-End Architecture Report
+
+### Executive Summary
+
+The `ptbr` toolkit contains a **showstopper configuration format incompatibility** between its two core CLIs: `config_cli.py` expects a YAML with top-level `gliner_config:` and `lora_config:` sections, while `training_cli.py` (and the shipped `template.yaml`) uses `model:`, `training:`, `lora:`, `environment:` sections. A user cannot use the same YAML file for both `python -m ptbr config` and `python -m ptbr train`. Beyond this fatal split, the toolkit is missing significant data features recommended by the research report (document schema fields, long-document chunking, preprocessing configuration), does not forward several parameters that `create_training_args` accepts via `**kwargs`, and deviates from the report's canonical YAML structure in naming and section organization.
+
+---
+
+### CRITICAL: Incompatible YAML Structures
+
+This is the most severe defect in the toolkit. The two CLIs that are both routed from the same `__main__.py` entry point expect **mutually exclusive** YAML layouts.
+
+**config_cli.py** (`/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/config_cli.py`):
+- Line 417: Checks for `raw["gliner_config"]` -- hard error if missing.
+- Line 448: Checks for `raw["lora_config"]` when in LoRA mode.
+- Validates fields like `gliner_config.model_name`, `gliner_config.span_mode`, etc.
+- Has **no awareness** of `model:`, `training:`, `data:`, `run:`, `environment:` sections.
+
+**training_cli.py** (`/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`):
+- Line 100: Schema expects `model.model_name`, `model.span_mode`, etc.
+- Line 142-145: Schema expects `data.root_dir`, `data.train_data`, `data.val_data_dir`.
+- Line 147-181: Schema expects `training.num_steps`, `training.lr_encoder`, etc.
+- Line 184-191: Schema expects `lora.enabled`, `lora.r`, etc.
+- Line 194-201: Schema expects `environment.push_to_hub`, `environment.wandb_project`, etc.
+- Has **no awareness** of `gliner_config:` or `lora_config:` sections.
+
+**template.yaml** (`/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/template.yaml`):
+- Uses the `training_cli.py` structure: `run:`, `model:`, `data:`, `training:`, `lora:`, `environment:`.
+- **Cannot** be validated by `config_cli.py` -- the config subcommand will immediately error with: `"Missing 'gliner_config' section in YAML file."`
+
+**Reproduction of the bug:**
+
+```bash
+# Step 1: Validate config (FAILS because template.yaml has no gliner_config: section)
+python -m ptbr config --file ptbr/template.yaml --validate
+
+# Step 2: Train (WORKS because training_cli.py expects model: section)
+python -m ptbr train ptbr/template.yaml --validate
+```
+
+This means the `config` subcommand is completely non-functional for any YAML file that works with the `train` subcommand, and vice versa. The two CLIs validate **different schemas for different YAML layouts** and there is no bridge, adapter, or shared format between them.
+
+**Root cause:** `config_cli.py` was written to validate the raw `GLiNERConfig` fields directly (as they appear in `gliner_config.json` on the Hub), while `training_cli.py` was written to validate a full experiment YAML with sectioned structure. Neither module knows about the other's format.
+
+**Additional incompatibility -- LoRA section naming:**
+- `config_cli.py` expects `lora_config:` (line 448), with fields like `r`, `lora_alpha`, `lora_dropout`, `target_modules`, `bias`, `task_type`, `modules_to_save`, `fan_in_fan_out`, `use_rslora`, `init_lora_weights`.
+- `training_cli.py` expects `lora:` (line 184), with fields like `enabled`, `r`, `lora_alpha`, `lora_dropout`, `bias`, `target_modules`, `task_type`, `modules_to_save`.
+- Even the field sets differ: `config_cli.py` has `fan_in_fan_out`, `use_rslora`, `init_lora_weights`; `training_cli.py` has `enabled` (master switch). They are not interchangeable.
+
+---
+
+### __main__.py Routing Analysis
+
+**File:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/__main__.py`
+
+The central dispatcher correctly registers three subcommands (`data`, `config`, `train`) but introduces an **inconsistent interface**:
+
+1. **Config subcommand** (lines 95-113): Defined as a Typer callback, takes `--file` as a named option (`typer.Option(...)`). Usage: `python -m ptbr config --file config.yaml --validate`.
+
+2. **Train subcommand** (line 120-122): Imports the `app` from `training_cli.py` and adds it as a sub-app. The training CLI's `main()` function (training_cli.py line 862-863) takes `config` as a **positional argument** (`typer.Argument(...)`). Usage: `python -m ptbr train config.yaml --validate`.
+
+**Inconsistency:** The config path is a named option (`--file`) for the config subcommand but a positional argument for the train subcommand. This is a UX inconsistency that will confuse users.
+
+3. **Data subcommand** (lines 27-86): Also uses `--file-or-repo` as a named option. This is consistent with config but not with train.
+
+4. **No shared validation path:** The `config_cmd` callback (line 96) calls `load_and_validate_config()` which expects the `gliner_config:` format. The `train` subcommand calls `validate_config()` which expects the `model:` format. There is no common validation function, no shared schema, and no way to run `config` validation as a pre-flight check for `train`.
+
+5. **Top-level import of training_cli** (line 120): `from ptbr.training_cli import app as _train_app` is executed at module load time. This means importing `__main__.py` (even just for the `config` or `data` subcommands) will execute `training_cli.py`'s module-level code, including setting up Rich logging handlers (training_cli.py lines 48-61). This is a side-effect that could cause issues with log output even when the user only wants to validate a config.
+
+---
+
+### Report's Canonical YAML vs Our Structure
+
+Side-by-side comparison:
+
+| Report Recommendation | Our `template.yaml` | Status |
+|---|---|---|
+| `experiment:` (metadata, seed, tags) | `run:` (name, description, tags, seed) | Renamed but functionally equivalent. Missing `data_seed`, `notes`. |
+| `model:` (GLiNER config) | `model:` (GLiNER config) | Structurally aligned. |
+| `peft:` with nested `lora:` sub-section | `lora:` (flat, no method/adapter_name) | Divergent. Report recommends `peft.enabled`, `peft.method`, `peft.adapter_name`, `peft.lora.r/alpha/...`. We have flat `lora.enabled`, `lora.r`, etc. Missing `method`, `adapter_name`, `init_lora_weights`, `use_rslora`. |
+| `data:` with `format`, `fields`, `preprocessing` sub-sections | `data:` with only `root_dir`, `train_data`, `val_data_dir` | **Major gap.** No schema fields, no format declaration, no preprocessing/chunking config. |
+| `training:` (full HF TrainingArguments + GLiNER extensions) | `training:` (subset of HF TrainingArguments) | Partial. Missing: `output_dir`, `overwrite_output_dir`, `save_safetensors`, `num_train_epochs`, `auto_find_batch_size`, `group_by_length`, `adam_beta1/beta2/epsilon`, `gradient_checkpointing`, `torch_compile` (as HF field), `evaluation_strategy`, `eval_steps`, `eval_delay`, `save_strategy`, `logging_strategy`, `logging_first_step`, `disable_tqdm`, `resume_from_checkpoint`, `remove_unused_columns`, `full_determinism`, `deepspeed`, `fsdp`, `hub_strategy`, `hub_private_repo`, `hub_always_push`, `run_name`, `load_best_model_at_end`, `metric_for_best_model`. |
+| `logging:` (W&B detailed config) | `environment:` (partial W&B config) | Divergent naming and missing fields. Report recommends `logging.wandb.project/entity/group/job_type/mode/log_model`. We have `environment.wandb_project/entity/api_key` only. Missing `group`, `job_type`, `mode`, `log_model`. |
+
+**Key structural divergences:**
+
+1. Report uses `experiment:` for metadata; we use `run:`. This is cosmetic.
+2. Report uses `peft:` with a nested `lora:` sub-section allowing future extensibility (e.g., QLoRA, prefix-tuning). We use a flat `lora:` section. This limits future extensibility.
+3. Report's `data:` section is significantly richer, with document schema and preprocessing. Ours is minimal.
+4. Report's `training:` section is a near-complete `TrainingArguments` mirror. Ours covers roughly 60% of the fields.
+5. Report separates `logging:` from environment. We merge W&B settings into `environment:`.
+
+---
+
+### Missing Data Features
+
+The research report explicitly recommends several data capabilities that are entirely absent from our implementation:
+
+**1. Document schema fields** (report's `data.fields`):
+
+The report recommends:
+```yaml
+data:
+  fields:
+    tokens: "tokenized_text"
+    ner: "ner"
+    relations: "relations"
+```
+
+Our `data.py` (`/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/data.py`) hardcodes the column names:
+- `load_data()` (line 26-31): Takes `text_column` and `ner_column` as parameters but they default to `"tokenized_text"` and `"ner"`.
+- The `data:` section in `template.yaml` has no field mapping configuration.
+- The `training_cli.py` schema (lines 142-145) only validates `data.root_dir`, `data.train_data`, `data.val_data_dir` -- no field mapping at all.
+
+**Impact:** If a user has a dataset with different column names (e.g., `"tokens"` instead of `"tokenized_text"`), the `data` subcommand supports remapping via CLI options, but the `train` subcommand has no mechanism for it. The training launcher (`_launch_training` at training_cli.py line 1064) does `json.load(f)` and passes the raw list directly to `model.train_model()` with no column mapping.
+
+**2. Long document chunking** (report's `data.preprocessing.long_doc_chunking`):
+
+The report recommends:
+```yaml
+data:
+  preprocessing:
+    long_doc_chunking:
+      enabled: false
+      max_words: 200
+      stride: 50
+      drop_empty_chunks: true
+```
+
+Our toolkit has **zero** preprocessing or chunking capabilities. Documents longer than `model.max_len` will simply be truncated by the tokenizer. There is no stride-based chunking, no option to split long documents into overlapping windows, and no way to configure this behavior.
+
+**3. Missing preprocessing section entirely:**
+
+The `data.py` module performs validation but not transformation. There is no:
+- Sentence splitting
+- Token normalization
+- Entity boundary adjustment after chunking
+- Train/validation split creation from a single file
+- Data augmentation (entity mention substitution, negative sampling pre-processing)
+
+---
+
+### Parameter Forwarding Gaps
+
+**Parameters validated by `training_cli.py` but NOT forwarded to `model.train_model()`:**
+
+Examining `_launch_training()` (training_cli.py lines 997-1132) and `create_training_args()` (model.py lines 1001-1087):
+
+| Parameter in Our Schema | Forwarded to `train_model()`? | Notes |
+|---|---|---|
+| `training.dataloader_pin_memory` | NO | Validated at line 174 but not passed at lines 1090-1132. |
+| `training.dataloader_persistent_workers` | NO | Validated at line 175 but not passed. |
+| `training.dataloader_prefetch_factor` | NO | Validated at line 176 but not passed. |
+| `training.size_sup` | NO | Validated at line 179 but never used. Dead config. |
+| `training.shuffle_types` | NO | Validated at line 180 but never forwarded. GLiNER internally handles this but our CLI doesn't forward it. |
+| `training.random_drop` | NO | Validated at line 181 but never forwarded. Same issue. |
+| `training.fp16` | Passed to `train_model()` at line 1124 | But `create_training_args()` does NOT have `fp16` as a named parameter (model.py line 1001-1027). It would need to go through `**kwargs`. |
+| `training.label_smoothing` | Passed to `train_model()` at line 1114 | But `create_training_args()` does NOT have `label_smoothing` as a named parameter. It goes through `**kwargs` and reaches `TrainingArguments` only if the custom `TrainingArguments` in `trainer.py` accepts it. It does (trainer.py line 82). This works but is fragile. |
+| `training.optim` | Passed as `optim=` (line 1109) | But `create_training_args()` does not have an `optim` named parameter. Uses `**kwargs`. Works but undocumented. |
+| `run.name` | NO | Validated, used for resume checking and log naming, but never passed to `TrainingArguments.run_name`. W&B will not see the run name. |
+| `run.tags` | NO | Validated and logged but never forwarded to W&B or TrainingArguments. |
+| `run.description` | NO | Validated but unused beyond logging. |
+
+**Parameters recommended by report but absent from our schema entirely:**
+
+- `training.output_dir` -- our CLI uses `--output-folder` CLI flag instead, which is good, but means the YAML cannot specify it.
+- `training.num_train_epochs` -- our schema only supports `num_steps`, not epoch-based training.
+- `training.adam_beta1`, `training.adam_beta2`, `training.adam_epsilon` -- not in schema, not forwarded.
+- `training.gradient_checkpointing` -- absent, important for large models.
+- `training.torch_compile` (as HF TrainingArguments field) -- we have `training.compile_model` which calls `model.compile()` directly rather than using the HF `torch_compile` arg.
+- `training.hub_strategy` -- absent, always pushes at end only.
+- `training.run_name` -- absent; `run.name` exists but is never forwarded.
+- `training.save_strategy`, `training.evaluation_strategy` -- absent; implied by `eval_every` field.
+- `training.resume_from_checkpoint` -- we use `--resume` CLI flag, not a config field.
+- `training.remove_unused_columns` -- absent. The report notes this is "often essential" for custom batch dictionaries.
+- `training.load_best_model_at_end`, `training.metric_for_best_model` -- absent.
+- `training.deepspeed`, `training.fsdp` -- absent, no distributed training support.
+- `logging.wandb.group`, `logging.wandb.job_type`, `logging.wandb.mode`, `logging.wandb.log_model` -- absent.
+
+---
+
+### Upstream train.py Compatibility
+
+**File:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/train.py`
+
+The upstream `train.py` uses `load_config_as_namespace()` from `gliner/utils.py`, which converts any YAML into nested `argparse.Namespace` objects by key. It then accesses:
+- `cfg.model` -> passed to `GLiNER.from_config(model_cfg)` as a dict
+- `cfg.training` -> used for training parameters
+- `cfg.data.root_dir`, `cfg.data.train_data`, `cfg.data.val_data_dir`
+
+**Compatibility assessment:**
+
+Our `template.yaml` uses the same top-level section names (`model:`, `training:`, `data:`) that `train.py` expects. Therefore, `template.yaml` **can** be used with the upstream `train.py` with these caveats:
+
+1. **Extra sections ignored:** The `run:`, `lora:`, and `environment:` sections in `template.yaml` are loaded into the namespace but never accessed by `train.py`. They are harmless.
+
+2. **Missing fields cause `AttributeError`:** The upstream `train.py` accesses `cfg.training.loss_prob_margin` via `getattr(cfg.training, "loss_prob_margin", 0.0)` (line 79), which handles missing fields. But it directly accesses `cfg.training.num_steps`, `cfg.training.scheduler_type`, etc. (lines 65-86) without `getattr` fallbacks. If any of these are missing, it crashes.
+
+3. **output_dir is hardcoded:** Upstream `train.py` passes `output_dir="models"` (line 63), ignoring `data.root_dir`. Our `training_cli.py` correctly uses the `--output-folder` flag.
+
+4. **bf16 is hardcoded:** Upstream `train.py` passes `bf16=True` (line 91), ignoring the config's `training.bf16` field. Our `training_cli.py` correctly reads from config.
+
+5. **eval_batch_size not forwarded:** Upstream `train.py` passes `per_device_eval_batch_size=cfg.training.train_batch_size` (line 70), always using the train batch size. Our `training_cli.py` has a proper fallback (line 1083).
+
+6. **label_smoothing not forwarded:** Upstream `train.py` does not forward `label_smoothing` at all. Our `training_cli.py` does (line 1114).
+
+**Verdict:** `template.yaml` works with upstream `train.py` for the basic case but several parameters validated by our toolkit will be silently ignored by upstream.
+
+---
+
+### End-to-End Workflow Gaps
+
+**Scenario: A user tries the documented workflow from `__init__.py`:**
+
+```bash
+python -m ptbr config --file config.yaml --validate && python -m ptbr train config.yaml
+```
+
+**What happens:**
+
+1. **If `config.yaml` follows `template.yaml` structure (model:/training:/data:):**
+   - `python -m ptbr config --file config.yaml --validate` **FAILS** immediately.
+   - Error: `"Missing 'gliner_config' section in YAML file."` (config_cli.py line 418)
+   - The `&&` short-circuits. Training never starts.
+   - The user sees a confusing error about a section they never intended to write.
+
+2. **If `config.yaml` follows the `config_cli.py` structure (gliner_config:/lora_config:):**
+   - `python -m ptbr config --file config.yaml --validate` **SUCCEEDS** (assuming valid GLiNER fields).
+   - `python -m ptbr train config.yaml` **FAILS** at multiple points:
+     - `validate_config()` will report all `model.*`, `run.*`, `data.*`, `training.*` fields as MISSING/REQUIRED errors.
+     - Even if validation were skipped, `_launch_training()` would crash with `KeyError: 'model'` at line 1043.
+
+3. **There is no YAML format that satisfies both CLIs simultaneously.** The `config` subcommand demands `gliner_config:` at the top level (which would be an unknown/extra key to `training_cli.py`), and the `train` subcommand demands `model:` at the top level (which `config_cli.py` would ignore completely while erroring on the absent `gliner_config:` key).
+
+**Additional workflow gaps:**
+
+- **No `init` or `template` command:** There is no way to generate a starter YAML from the CLI. Users must find and copy `template.yaml` manually.
+- **No format migration:** If a user has a `gliner_config.json` from the Hub, there is no tool to convert it into our YAML format.
+- **No dry-run for training:** The `--validate` flag on the train subcommand exits after validation (training_cli.py line 967-968), but it still requires `--output-folder` to be unset or empty (line 971-973), meaning you cannot validate a config that is already partially trained.
+- **Log file pollution:** Both CLIs create log/summary files in the config directory. Running validation repeatedly creates `validation_*.log`, `summary_*.txt`, and `config_validation_*.json` files with no cleanup mechanism.
+
+---
+
+### Concrete Recommendations
+
+**Priority 1 (Showstoppers):**
+
+1. **Unify the YAML format between `config_cli.py` and `training_cli.py`.** The most pragmatic approach is to make `config_cli.py` understand the `model:` structure used by `training_cli.py` and `template.yaml`. Specifically:
+   - `config_cli.py` line 417: Change `if "gliner_config" not in raw:` to also accept `if "model" not in raw:` and treat the `model:` section as the source of GLiNER config fields.
+   - `config_cli.py` line 448: Change `if "lora_config" not in raw:` to also accept `if "lora" not in raw:`.
+   - Alternatively, rewrite `config_cli.py` to consume the same `_FIELD_SCHEMA` structure from `training_cli.py`, extracting only the `model.*` and `lora.*` fields for its GLiNER/LoRA validation.
+   - **Files:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/config_cli.py` lines 417-464.
+
+2. **Forward `run.name` as `run_name` to `TrainingArguments`.** Without this, W&B runs are unnamed.
+   - **File:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, `_launch_training()`, around line 1090. Add `run_name=cfg["run"]["name"]` to the `model.train_model()` call.
+
+**Priority 2 (Important):**
+
+3. **Forward missing dataloader parameters.** `dataloader_pin_memory`, `dataloader_persistent_workers`, `dataloader_prefetch_factor` are validated but never passed.
+   - **File:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py` lines 1090-1132. Add the three parameters to the `model.train_model()` call.
+
+4. **Remove dead config fields or wire them.** `training.size_sup`, `training.shuffle_types`, `training.random_drop` are validated but never forwarded. Either remove them from `_FIELD_SCHEMA` (training_cli.py lines 179-181) or forward them to the trainer.
+
+5. **Add `remove_unused_columns=False` as a default.** The report explicitly warns this is "often essential for custom batch dictionaries." GLiNER uses custom data collators, making this critical.
+   - **File:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py` line 1090-1132. Add `remove_unused_columns=False` to the `model.train_model()` call.
+
+6. **Add `data.fields` schema to template.yaml and training_cli schema.** Allow users to specify custom column name mappings so that `_launch_training()` can remap columns before passing to the trainer.
+   - **Files:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/template.yaml` (add `fields:` sub-section under `data:`), `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py` (add schema entries, update `_launch_training()`).
+
+7. **Standardize CLI argument style.** The `config` subcommand uses `--file` (a named option) while `train` uses a positional argument. Either make both positional or both named.
+   - **Files:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/__main__.py` lines 97 and 120-122.
+
+8. **Add `gradient_checkpointing` to the schema.** This is essential for fine-tuning large models on consumer GPUs and is a standard `TrainingArguments` field.
+   - **File:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py` `_FIELD_SCHEMA`, add entry for `training.gradient_checkpointing`.
+
+**Priority 3 (Nice-to-have):**
+
+9. **Add long-document chunking to `data.py`.** Implement the report's recommended `data.preprocessing.long_doc_chunking` with `max_words`, `stride`, and `drop_empty_chunks` parameters.
+   - **File:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/data.py`.
+
+10. **Add a `peft:` wrapper section** around the LoRA config to allow future extensibility (QLoRA, prefix-tuning, IA3). Include `method` and `adapter_name` fields as the report recommends.
+    - **Files:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/template.yaml`, `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`.
+
+11. **Add distributed training placeholders** (`deepspeed`, `fsdp`) to the schema, even if not yet wired. This prevents users from having to modify the schema later.
+    - **File:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py` `_FIELD_SCHEMA`.
+
+12. **Add `hub_strategy`, `hub_private_repo`, `hub_always_push`** to the environment section to match the report's Hub integration recommendations.
+    - **Files:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/template.yaml`, `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`.
+
+13. **Add a `ptbr init` command** that generates a starter YAML from the template, optionally with a model name pre-filled.
+    - **File:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/__main__.py`.
+
+14. **Lazy-import training_cli in __main__.py** to avoid module-level side effects (Rich handler setup) when only using `config` or `data` subcommands.
+    - **File:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/__main__.py` line 120. Move the import inside a function or use Typer's lazy loading pattern.
+
+15. **Add W&B run tags forwarding.** The `run.tags` field is validated but never forwarded to W&B via `WANDB_TAGS` environment variable or TrainingArguments.
+    - **File:** `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py` `_launch_training()`, around line 1030-1040.

--- a/research/standard_config.md
+++ b/research/standard_config.md
@@ -1,0 +1,38 @@
+# Research Topic: Standard HuggingFace Configuration
+
+## Source: deep-research-report.md (sections on TrainingArguments, Hub integration, W&B)
+
+### Key Findings from Report
+
+**TrainingArguments fields that belong under `training:`:**
+- Optimization: `learning_rate`, `weight_decay`, `optim`, `adam_*`, schedulers, warmup
+- Batch and steps: `per_device_*_batch_size`, `gradient_accumulation_steps`, `max_steps`, `num_train_epochs`
+- Precision/perf: `bf16`, `fp16`, `tf32`, `gradient_checkpointing`, `torch_compile`
+- Logging/saving: `logging_steps`, `save_steps`, `evaluation_strategy`, `eval_steps`, `save_total_limit`
+- Integrations: `report_to`, `run_name`, `push_to_hub` and hub settings
+- Distributed: `deepspeed`, `fsdp`, ddp knobs
+
+**Hub sync fields (standard TrainingArguments):**
+- `push_to_hub`, `hub_model_id`, `hub_strategy`, `hub_token`, `hub_private_repo`, `hub_always_push`
+
+**W&B tracking:**
+- `report_to="wandb"`, `run_name`, `logging_steps`
+- Extra script-level: `WANDB_PROJECT`, `WANDB_ENTITY`, `WANDB_API_KEY`, `WANDB_LOG_MODEL`
+
+**Red flags from W&B dump:**
+- `warmup_steps` shown as 0.05 (float) - should be `warmup_ratio: 0.05` with `warmup_steps: 0`
+
+**Professional extras to include even if not wired yet:**
+- Resume: `resume_from_checkpoint`
+- Determinism: `full_determinism`
+- Model selection: `load_best_model_at_end`, `metric_for_best_model`, `greater_is_better`
+- Distributed: `deepspeed`, `fsdp` config keys
+
+### Analysis Task
+
+Critically compare our `training_cli.py` and `template.yaml` against the report's recommendations for standard HuggingFace TrainingArguments. Document:
+1. Which recommended fields are present and correctly placed
+2. Which recommended fields are missing
+3. Which fields deviate from the report's recommendations
+4. Specific gaps in Hub integration and W&B support
+5. Whether `warmup_ratio` vs `warmup_steps` is handled correctly

--- a/research/standard_config_report.md
+++ b/research/standard_config_report.md
@@ -1,0 +1,280 @@
+## Standard HuggingFace Configuration Report
+
+### Executive Summary
+
+Our implementation (`training_cli.py` + `template.yaml`) covers the core GLiNER-specific and basic HuggingFace TrainingArguments fields but **falls significantly short** of the deep research report's recommendations for Hub integration, W&B tracking, distributed training, model selection, resume handling, and several standard TrainingArguments knobs. Approximately 35+ recommended fields are either entirely absent or placed in non-standard locations, and multiple forwarding gaps exist where our CLI validates a field but never passes it through to the upstream `train_model()` call.
+
+### Fields Present and Correct
+
+| Field Name | Our Location | Report Recommendation | Status |
+|---|---|---|---|
+| `learning_rate` (encoder) | `training.lr_encoder` | `training.learning_rate` | PARTIAL -- present but named differently; forwarded correctly to `learning_rate=` kwarg |
+| `weight_decay` (encoder) | `training.weight_decay_encoder` | `training.weight_decay` | PARTIAL -- present but named differently; forwarded correctly |
+| `others_lr` | `training.lr_others` | `training.others_lr` | PARTIAL -- named differently; forwarded correctly |
+| `others_weight_decay` | `training.weight_decay_other` | `training.others_weight_decay` | PARTIAL -- named differently; forwarded correctly |
+| `optim` / `optimizer` | `training.optimizer` | `training.optim` | PARTIAL -- named `optimizer` in our schema vs `optim` in HF; forwarded as `optim=` kwarg |
+| `lr_scheduler_type` | `training.scheduler_type` | `training.lr_scheduler_type` | PARTIAL -- named differently; forwarded correctly |
+| `warmup_ratio` | `training.warmup_ratio` | `training.warmup_ratio` | OK |
+| `per_device_train_batch_size` | `training.train_batch_size` | `training.per_device_train_batch_size` | PARTIAL -- named differently; forwarded correctly |
+| `per_device_eval_batch_size` | `training.eval_batch_size` | `training.per_device_eval_batch_size` | PARTIAL -- named differently; forwarded correctly |
+| `gradient_accumulation_steps` | `training.gradient_accumulation_steps` | `training.gradient_accumulation_steps` | OK |
+| `max_grad_norm` | `training.max_grad_norm` | `training.max_grad_norm` | OK |
+| `max_steps` | `training.num_steps` | `training.max_steps` | PARTIAL -- named differently; forwarded as `max_steps=` |
+| `save_steps` | `training.eval_every` | `training.save_steps` | PARTIAL -- aliased through `eval_every`; forwarded correctly |
+| `save_total_limit` | `training.save_total_limit` | `training.save_total_limit` | OK |
+| `logging_steps` | `training.logging_steps` | `training.logging_steps` | OK |
+| `bf16` | `training.bf16` | `training.bf16` | OK |
+| `fp16` | `training.fp16` | `training.fp16` | PARTIAL -- validated in schema but **not forwarded** to `train_model()` as `fp16=` kwarg |
+| `use_cpu` | `training.use_cpu` | N/A (not in report) | OK -- extra field |
+| `report_to` | `environment.report_to` | `training.report_to` | DEVIATION -- placed in `environment` section, not `training` |
+| `push_to_hub` | `environment.push_to_hub` | `training.push_to_hub` | DEVIATION -- placed in `environment` section, not `training` |
+| `hub_model_id` | `environment.hub_model_id` | `training.hub_model_id` | DEVIATION -- placed in `environment` section, not `training` |
+| `dataloader_num_workers` | `training.dataloader_num_workers` | `training.dataloader_num_workers` | OK |
+| `dataloader_pin_memory` | `training.dataloader_pin_memory` | `training.dataloader_pin_memory` | OK -- but **not forwarded** to `train_model()` |
+| `dataloader_persistent_workers` | `training.dataloader_persistent_workers` | `training.dataloader_persistent_workers` | OK -- but **not forwarded** |
+| `dataloader_prefetch_factor` | `training.dataloader_prefetch_factor` | `training.dataloader_prefetch_factor` | OK -- but **not forwarded** |
+| `focal_loss_alpha` | `training.loss_alpha` | `training.focal_loss_alpha` | PARTIAL -- named differently; forwarded correctly |
+| `focal_loss_gamma` | `training.loss_gamma` | `training.focal_loss_gamma` | PARTIAL -- named differently; forwarded correctly |
+| `focal_loss_prob_margin` | `training.loss_prob_margin` | `training.focal_loss_prob_margin` | PARTIAL -- named differently; forwarded correctly |
+| `label_smoothing` | `training.label_smoothing` | `training.label_smoothing` | OK |
+| `loss_reduction` | `training.loss_reduction` | `training.loss_reduction` | OK |
+| `negatives` | `training.negatives` | `training.negatives` | OK |
+| `masking` | `training.masking` | `training.masking` | OK |
+| `seed` | `run.seed` | `experiment.seed` | PARTIAL -- different section name but functional |
+| `compile_model` / `torch_compile` | `training.compile_model` | `training.torch_compile` | PARTIAL -- named differently; forwarded correctly |
+
+### Missing Fields (Critical Gaps)
+
+The following fields are recommended by the deep research report but are **completely absent** from both `_FIELD_SCHEMA` in `training_cli.py` and `template.yaml`:
+
+#### Standard TrainingArguments (High Priority)
+
+1. **`warmup_steps`** -- integer warmup steps (report says: include and set to `0` explicitly when using `warmup_ratio`)
+2. **`num_train_epochs`** -- alternative to `max_steps` for epoch-based training
+3. **`evaluation_strategy`** -- HF standard field (`"steps"`, `"epoch"`, `"no"`)
+4. **`eval_steps`** -- distinct from `save_steps` (we alias both to `eval_every`)
+5. **`save_strategy`** -- HF standard (`"steps"`, `"epoch"`, `"no"`)
+6. **`overwrite_output_dir`** -- standard TrainingArguments field
+7. **`save_safetensors`** -- controls safetensors serialization format
+8. **`do_train`** / **`do_eval`** -- script convention flags
+9. **`eval_delay`** -- number of steps/epochs to delay first evaluation
+10. **`eval_on_start`** -- evaluate before training begins
+11. **`auto_find_batch_size`** -- automatic batch size finder
+12. **`group_by_length`** -- group samples by length for efficiency
+13. **`length_column_name`** -- column name for length grouping
+14. **`remove_unused_columns`** -- critical for custom batch dictionaries (report notes GLiNER needs `false`)
+
+#### Optimizer Details (Medium Priority)
+
+15. **`adam_beta1`** -- Adam beta1 parameter (default 0.9)
+16. **`adam_beta2`** -- Adam beta2 parameter (default 0.999)
+17. **`adam_epsilon`** -- Adam epsilon (default 1e-8)
+
+#### Precision and Performance (Medium Priority)
+
+18. **`tf32`** -- TF32 precision mode
+19. **`gradient_checkpointing`** -- memory optimization
+20. **`torch_compile`** (as standard HF name) -- we use `compile_model` instead
+
+#### Logging Details (Medium Priority)
+
+21. **`logging_strategy`** -- `"steps"` / `"epoch"` / `"no"`
+22. **`logging_first_step`** -- log metrics on first step
+23. **`logging_dir`** -- TensorBoard log directory
+24. **`disable_tqdm`** -- disable progress bar
+25. **`log_level`** -- Trainer log level
+26. **`log_level_replica`** -- log level for replicas
+27. **`run_name`** -- W&B run name (standard TrainingArguments field)
+
+#### Dataloader Details (Low Priority)
+
+28. **`dataloader_drop_last`** -- drop last incomplete batch
+29. **`skip_memory_metrics`** -- skip memory profiling
+30. **`save_on_each_node`** -- save on each distributed node
+
+#### Resume and Determinism (High Priority)
+
+31. **`resume_from_checkpoint`** -- standard HF checkpoint resume path
+32. **`ignore_data_skip`** -- skip data fast-forward on resume
+33. **`full_determinism`** -- enforce full deterministic training
+
+#### Model Selection (High Priority)
+
+34. **`load_best_model_at_end`** -- load best checkpoint at end of training
+35. **`metric_for_best_model`** -- metric to determine best model
+36. **`greater_is_better`** -- whether higher metric is better
+
+#### Distributed Training (Medium Priority)
+
+37. **`deepspeed`** -- DeepSpeed config path
+38. **`fsdp`** -- FSDP sharding strategy
+39. **`fsdp_config`** -- FSDP configuration dict
+40. **`ddp_backend`** -- DDP communication backend
+41. **`ddp_timeout`** -- DDP timeout
+42. **`local_rank`** -- local rank for distributed
+
+### Deviations from Report
+
+#### 1. Section Structure Mismatch
+
+The report recommends a **four-section** layout: `model:`, `training:`, `data:`, `peft:` (with an optional `logging:` or `experiment:` section). Our implementation uses a **six-section** layout: `run:`, `model:`, `data:`, `training:`, `lora:`, `environment:`.
+
+Key differences:
+- **`run:` section**: Report puts `name`, `seed`, `tags` under `experiment:`. We use `run:`. This is cosmetic but inconsistent.
+- **`environment:` section**: Report puts Hub and W&B fields under `training:` (since they are standard `TrainingArguments` fields). We segregate them into `environment:`. This is a **structural deviation** -- `push_to_hub`, `hub_model_id`, `report_to`, and `run_name` are all standard `TrainingArguments` parameters and should live under `training:` per HF convention.
+- **`lora:` vs `peft:`**: Report uses `peft:` with a nested `lora:` sub-section. We use a flat `lora:` section. Our approach lacks the `method`, `adapter_name`, `init_lora_weights`, and `use_rslora` fields.
+
+#### 2. Field Naming Inconsistencies
+
+Our CLI uses GLiNER-legacy field names instead of standard HF TrainingArguments names:
+
+| Our Name | HF Standard Name | Notes |
+|---|---|---|
+| `training.num_steps` | `max_steps` | Legacy GLiNER naming |
+| `training.train_batch_size` | `per_device_train_batch_size` | Legacy GLiNER naming |
+| `training.eval_batch_size` | `per_device_eval_batch_size` | Legacy GLiNER naming |
+| `training.lr_encoder` | `learning_rate` | GLiNER-specific but maps correctly |
+| `training.lr_others` | `others_lr` | GLiNER extension |
+| `training.scheduler_type` | `lr_scheduler_type` | Shortened name |
+| `training.eval_every` | `save_steps` + `eval_steps` | Conflates save and eval intervals |
+| `training.loss_alpha` | `focal_loss_alpha` | Shortened name |
+| `training.loss_gamma` | `focal_loss_gamma` | Shortened name |
+| `training.loss_prob_margin` | `focal_loss_prob_margin` | Shortened name |
+| `training.optimizer` | `optim` | Different name |
+| `training.compile_model` | `torch_compile` | Different name |
+
+This creates a translation layer that makes it harder to reason about which HF TrainingArguments are actually being set.
+
+#### 3. `eval_every` Conflates Two Distinct HF Concepts
+
+Our `training.eval_every` is used for both `save_steps` and (implicitly) `eval_steps`. The report recommends separate `save_steps`, `eval_steps`, `save_strategy`, and `evaluation_strategy` fields, since in practice you often want to evaluate more frequently than you save checkpoints.
+
+#### 4. `report_to` Type Mismatch
+
+The report shows `report_to: ["wandb"]` (a list), matching HF TrainingArguments which accepts `List[str]` or `str`. Our schema declares `report_to` as `str` type, which means you cannot specify multiple backends like `["wandb", "tensorboard"]`.
+
+#### 5. Forwarding Gaps in `_launch_training()`
+
+Several fields are validated in the schema but **never forwarded** to `model.train_model()`:
+
+- `training.fp16` -- validated but not passed (line 1123 passes `bf16=` but the `fp16=` kwarg is missing from the call at line 1090-1132)
+- `training.dataloader_pin_memory` -- validated but not passed
+- `training.dataloader_persistent_workers` -- validated but not passed
+- `training.dataloader_prefetch_factor` -- validated but not passed
+- `environment.push_to_hub` -- validated but not passed to TrainingArguments
+- `environment.hub_model_id` -- validated but not passed to TrainingArguments
+- `run.name` -- validated but not forwarded as `run_name` to TrainingArguments (which would set the W&B run name)
+
+These represent "dead" configuration: the user sets them, validation passes, but the actual training run ignores them.
+
+### Hub Integration Gaps
+
+The report identifies the following standard `TrainingArguments` Hub fields as essential for professional workflows:
+
+| Field | Report Recommendation | Our Implementation | Gap |
+|---|---|---|---|
+| `push_to_hub` | `training.push_to_hub` | `environment.push_to_hub` -- validated but **never forwarded** to TrainingArguments | CRITICAL: field exists but is dead weight; push never actually happens via Trainer |
+| `hub_model_id` | `training.hub_model_id` | `environment.hub_model_id` -- validated but **never forwarded** | CRITICAL: same as above |
+| `hub_strategy` | `training.hub_strategy` (`"every_save"`, `"end"`, etc.) | **MISSING** | CRITICAL: no way to control when models are pushed |
+| `hub_token` | `training.hub_token` | `environment.hf_token` -- validated for connectivity check but **never forwarded** to TrainingArguments | CRITICAL: Trainer cannot authenticate to Hub |
+| `hub_private_repo` | `training.hub_private_repo` | **MISSING** | No way to create private Hub repos |
+| `hub_always_push` | `training.hub_always_push` | **MISSING** | No way to force push on every save |
+| `hub_revision` | `training.hub_revision` | **MISSING** | No way to push to a specific branch/revision |
+
+**Net effect**: Even if a user sets `push_to_hub: true` and `hub_model_id: "org/model"`, the model is **never actually pushed** because these values are only used for a connectivity check in `check_huggingface()` but are never passed through to the HF Trainer's `TrainingArguments`. The user gets a false sense of security from the validation passing.
+
+### W&B Gaps
+
+| Feature | Report Recommendation | Our Implementation | Gap |
+|---|---|---|---|
+| `report_to` | `training.report_to: ["wandb"]` (list) | `environment.report_to: "none"` (string) -- forwarded to `train_model()` | Type mismatch (str vs list); placed in wrong section |
+| `run_name` | `training.run_name` (standard TrainingArguments) | **MISSING** -- `run.name` exists but is never forwarded as `run_name=` to TrainingArguments | W&B runs get auto-generated names instead of user-specified names |
+| `WANDB_PROJECT` | Set via env var | `environment.wandb_project` -- forwarded to `os.environ["WANDB_PROJECT"]` | OK -- functional |
+| `WANDB_ENTITY` | Set via env var | `environment.wandb_entity` -- forwarded to `os.environ["WANDB_ENTITY"]` | OK -- functional |
+| `WANDB_API_KEY` | Set via env var | `environment.wandb_api_key` -- forwarded to `os.environ["WANDB_API_KEY"]` | OK -- functional |
+| `WANDB_LOG_MODEL` | `logging.wandb.log_model: "checkpoint"` | **MISSING** | No model artifact logging to W&B |
+| `WANDB_MODE` | `logging.wandb.mode` (`"online"`, `"offline"`, `"disabled"`) | **MISSING** | Cannot control W&B mode |
+| `WANDB_GROUP` | `logging.wandb.group` | **MISSING** | Cannot group related runs |
+| `WANDB_JOB_TYPE` | `logging.wandb.job_type` | **MISSING** | Cannot tag job type |
+| `logging_first_step` | `training.logging_first_step: true` | **MISSING** | First step metrics not guaranteed to be logged |
+| `logging_strategy` | `training.logging_strategy: "steps"` | **MISSING** | Implicit "steps" only |
+
+**Net effect**: W&B runs will have auto-generated names (not the user's `run.name`), no model artifacts logged, and limited organizational metadata. The `run.name` field is validated and displayed in the summary table but never reaches HF Trainer.
+
+### warmup_ratio vs warmup_steps
+
+**Report finding**: The W&B dump showed `warmup_steps: 0.05` (a float), which is a red flag. HF TrainingArguments defines `warmup_steps` as an **integer** (number of steps) and `warmup_ratio` as a **float** (fraction of total steps). If both are set, `warmup_steps > 0` overrides `warmup_ratio`.
+
+**Our implementation**:
+- `training.warmup_ratio` is present, typed as `float`, bounded to `[0.0, 1.0]` -- **CORRECT**.
+- `training.warmup_steps` (integer) is **ABSENT**.
+- `warmup_ratio` is forwarded to `train_model()` at line 1099 of `training_cli.py` -- **CORRECT**.
+
+**Assessment**: Our handling is **partially correct** but incomplete. We correctly use `warmup_ratio` as a float and forward it. However:
+1. We do not expose `warmup_steps` at all, so users cannot override with an explicit integer step count.
+2. We do not explicitly set `warmup_steps=0` in the TrainingArguments call, relying on the HF default (which is `0`, so this works in practice).
+3. There is no cross-validation to prevent a user from somehow passing both (though since `warmup_steps` is not in our schema, this is unlikely).
+
+**Verdict**: Functionally correct for the `warmup_ratio`-only path. Missing the `warmup_steps` escape hatch recommended by the report.
+
+### Professional Extras Missing
+
+| Feature | Report Section | Status in Our Code | Impact |
+|---|---|---|---|
+| `resume_from_checkpoint` | Resume/determinism | **MISSING** from schema and forwarding. Our `--resume` CLI flag does a name-matching check on checkpoint dirs but never actually sets `resume_from_checkpoint` in TrainingArguments | Resume does not actually resume training; it only validates checkpoint existence |
+| `full_determinism` | Resume/determinism | **MISSING** | Cannot guarantee bitwise reproducibility |
+| `load_best_model_at_end` | Model selection | **MISSING** | After training, the last checkpoint is loaded regardless of performance |
+| `metric_for_best_model` | Model selection | **MISSING** | No metric-based model selection |
+| `greater_is_better` | Model selection | **MISSING** | Required companion to `metric_for_best_model` |
+| `deepspeed` | Distributed | **MISSING** | Cannot use DeepSpeed ZeRO stages |
+| `fsdp` | Distributed | **MISSING** | Cannot use PyTorch FSDP |
+| `fsdp_config` | Distributed | **MISSING** | No FSDP configuration |
+| `ddp_backend` | Distributed | **MISSING** | Cannot specify NCCL/Gloo backend |
+| `ddp_timeout` | Distributed | **MISSING** | No DDP timeout control |
+| `local_rank` | Distributed | **MISSING** | No explicit local rank |
+| `gradient_checkpointing` | Precision/perf | **MISSING** | Cannot trade compute for memory |
+| `tf32` | Precision/perf | **MISSING** | Cannot enable TF32 on Ampere+ GPUs |
+| `data_seed` | Determinism | **MISSING** | Cannot independently seed data shuffling |
+| `save_safetensors` | Saving | **MISSING** | No control over serialization format |
+
+### Concrete Recommendations
+
+1. **Move Hub and W&B fields from `environment:` to `training:`** (`training_cli.py:194-201`, `template.yaml:496-540`). Fields `push_to_hub`, `hub_model_id`, `hub_strategy`, `hub_token`, `hub_private_repo`, `hub_always_push`, `report_to`, and `run_name` are all standard `TrainingArguments` parameters. Keep `environment:` only for script-level env vars (`cuda_visible_devices`, `wandb_api_key` override).
+
+2. **Forward Hub fields to `train_model()`** (`training_cli.py:1090-1132`). Add `push_to_hub=`, `hub_model_id=`, `hub_strategy=`, `hub_token=`, `hub_private_repo=`, `hub_always_push=` kwargs to the `model.train_model()` call. Currently these are validated but silently discarded.
+
+3. **Forward `run_name` to TrainingArguments** (`training_cli.py:1090-1132`). Add `run_name=cfg["run"]["name"]` to the `train_model()` call so W&B runs get the user's chosen name.
+
+4. **Forward missing dataloader and precision fields** (`training_cli.py:1126-1128`). Add `fp16=`, `dataloader_pin_memory=`, `dataloader_persistent_workers=`, `dataloader_prefetch_factor=` to the `train_model()` call. These are validated but never passed through.
+
+5. **Add `hub_strategy`, `hub_private_repo`, `hub_always_push`, `hub_revision` to schema** (`training_cli.py:92-202`). Add to `_FIELD_SCHEMA` with appropriate types and defaults. Add corresponding entries to `template.yaml`.
+
+6. **Add `WANDB_LOG_MODEL` support** (`training_cli.py:1029-1040`). In the W&B env var setup block, add `os.environ["WANDB_LOG_MODEL"] = cfg["environment"].get("wandb_log_model", "false")` or similar. Add `environment.wandb_log_model` to the schema.
+
+7. **Add `resume_from_checkpoint` and actually wire resume** (`training_cli.py:997-1134`). The current `--resume` flag checks for checkpoint existence but never passes the checkpoint path to `train_model()`. Add `resume_from_checkpoint=str(latest_checkpoint)` to the `train_model()` kwargs, or add a `training.resume_from_checkpoint` schema field.
+
+8. **Separate `eval_steps` from `save_steps`** (`training_cli.py:167`, `template.yaml:373`). Replace the single `eval_every` with distinct `save_steps` and `eval_steps` fields (both defaulting to the same value for backward compatibility). Add `evaluation_strategy` and `save_strategy` fields.
+
+9. **Add model selection fields** (`training_cli.py:92-202`). Add `training.load_best_model_at_end` (bool, default `false`), `training.metric_for_best_model` (str, default `null`), `training.greater_is_better` (bool, default `null`) to the schema and forward them.
+
+10. **Add distributed training fields** (`training_cli.py:92-202`). Add `training.deepspeed` (str/null), `training.fsdp` (list), `training.fsdp_config` (dict), `training.ddp_backend` (str/null), `training.ddp_timeout` (int) as placeholder fields even if not actively used, to prepare for scaling.
+
+11. **Add `gradient_checkpointing` and `tf32`** (`training_cli.py:92-202`). Add to schema and forward to `train_model()`. These are high-impact performance knobs.
+
+12. **Add `warmup_steps` as an explicit integer field** (`training_cli.py:150`). Add `training.warmup_steps` (int, default `0`) and add a semantic cross-check: if both `warmup_ratio > 0` and `warmup_steps > 0`, emit a warning that `warmup_steps` will take precedence.
+
+13. **Change `report_to` type from `str` to `list|str`** (`training_cli.py:197`). HF TrainingArguments accepts `List[str]` for `report_to`. Update the schema type and validation.
+
+14. **Add `adam_beta1`, `adam_beta2`, `adam_epsilon`** (`training_cli.py:92-202`). These are standard optimizer hyperparameters that should be exposed for reproducibility.
+
+15. **Add LoRA `init_lora_weights` and `use_rslora`** (`training_cli.py:184-191`). The report recommends these PEFT fields. Also consider renaming the section from `lora:` to `peft:` with a nested `lora:` sub-section for future extensibility (e.g., adding `method: "lora"` or `method: "qlora"`).
+
+16. **Add `data_seed` field** (`training_cli.py:92-98`). Add under `run:` section (alongside `seed`) for independent data shuffling seed control.
+
+17. **Rename fields to match HF conventions** (optional but strongly recommended). Consider adding aliases or renaming `num_steps` -> `max_steps`, `train_batch_size` -> `per_device_train_batch_size`, `scheduler_type` -> `lr_scheduler_type`, etc. This reduces cognitive overhead when cross-referencing with HF documentation.
+
+18. **Add `logging_first_step: true` and `logging_strategy`** (`training_cli.py:92-202`). These ensure W&B gets metrics from step 0, which is valuable for debugging learning rate warmup and initial loss values.
+
+19. **Forward `save_safetensors=True` to TrainingArguments** (`training_cli.py:1090-1132`). The upstream Trainer `_save()` method at `gliner/training/trainer.py:107` checks `self.args.save_safetensors`, but we never set this argument. Default should be `true` for modern workflows.
+
+20. **Add `remove_unused_columns: false` to TrainingArguments** (`training_cli.py:1090-1132`). The report explicitly notes this is essential for GLiNER's custom batch dictionaries. Without it, HF Trainer may silently drop columns needed by GLiNER's `compute_loss()`.

--- a/research/training_parameters.md
+++ b/research/training_parameters.md
@@ -1,0 +1,38 @@
+# Research Topic: Training Parameters and Loss Configuration
+
+## Source: deep-research-report.md (sections on Trainer extensions, LoRA, loss knobs)
+
+### Key Findings from Report
+
+**GLiNER-specific Trainer extensions (training-only, not standard HF):**
+- `others_lr`, `others_weight_decay`
+- `focal_loss_alpha`, `focal_loss_gamma`, `focal_loss_prob_margin`
+- `label_smoothing`, `loss_reduction`
+- `negatives`, `masking`
+
+**LoRA/PEFT recommendations:**
+- LoRA belongs in "training config" not "model config" (optimization strategy)
+- Start with `r in {8, 16, 32}`, `lora_alpha ~ 2r`, `lora_dropout in [0.05, 0.1]`
+- Apply to attention projections (`target_modules` model-dependent)
+- Keep `bias="none"` unless needed
+- Key PEFT fields: `r`, `lora_alpha`, `lora_dropout`, `bias`, `target_modules`, `modules_to_save`, `init_lora_weights`, `use_rslora`
+
+**Parameter flow (from Mermaid diagram):**
+- YAML -> model (GLiNER.from_config) -> GLiNER model + processors
+- YAML -> training (GLiNER.train_model) -> HF Trainer + custom GLiNER Trainer
+- YAML -> peft (Script applies PEFT to backbone) -> model
+- YAML -> data (Dataset loader + preprocessing) -> Trainer
+
+**Key decision rule:**
+- If parameter changes how gradients flow / optimizer / evaluate / save / log -> trainer config
+- freeze_components is listed under training but could be GLiNER-specific
+
+### Analysis Task
+
+Critically compare our `training_cli.py` training and lora schema sections against the report. Document:
+1. Whether GLiNER extension fields are correctly identified and separated from standard HF
+2. Whether LoRA configuration matches PEFT best practices from the report
+3. Whether our `_launch_training` correctly maps config fields to `model.train_model()` kwargs
+4. Missing training parameters the report recommends
+5. Whether loss function parameters are correctly wired (focal loss, label smoothing)
+6. Whether the parameter flow matches the report's recommended architecture

--- a/research/training_parameters_report.md
+++ b/research/training_parameters_report.md
@@ -1,0 +1,293 @@
+## Training Parameters and Loss Configuration Report
+
+### Executive Summary
+
+Our training toolkit has a well-structured validation layer (`_FIELD_SCHEMA` in `training_cli.py`) and correctly identifies most GLiNER-specific extension fields. However, there are critical gaps: three validated fields (`size_sup`, `shuffle_types`, `random_drop`) are never forwarded to training, three forwarded dataloader fields (`dataloader_pin_memory`, `dataloader_persistent_workers`, `dataloader_prefetch_factor`) rely on `**kwargs` pass-through without explicit documentation, `label_smoothing` is similarly implicit, the LoRA implementation is missing three PEFT fields (`init_lora_weights`, `use_rslora`, `fan_in_fan_out`) that `config_cli.py` already validates, and several high-impact TrainingArguments fields recommended by the research report are completely absent from the schema.
+
+---
+
+### GLiNER Extension Fields
+
+The research report identifies these as GLiNER-specific Trainer extensions (not standard HF `TrainingArguments`):
+
+| Field | In our schema? | Correctly classified? | Notes |
+|---|---|---|---|
+| `others_lr` | Yes (`training.lr_others`) | Yes | Correctly treated as training, mapped to `others_lr` kwarg |
+| `others_weight_decay` | Yes (`training.weight_decay_other`) | Yes | Correctly treated as training |
+| `focal_loss_alpha` | Yes (`training.loss_alpha`) | Yes | Mapped to `focal_loss_alpha` kwarg |
+| `focal_loss_gamma` | Yes (`training.loss_gamma`) | Yes | Mapped to `focal_loss_gamma` kwarg |
+| `focal_loss_prob_margin` | Yes (`training.loss_prob_margin`) | Yes | Mapped to `focal_loss_prob_margin` kwarg |
+| `label_smoothing` | Yes (`training.label_smoothing`) | Yes | Mapped correctly |
+| `loss_reduction` | Yes (`training.loss_reduction`) | Yes | Mapped correctly |
+| `negatives` | Yes (`training.negatives`) | Yes | Mapped correctly |
+| `masking` | Yes (`training.masking`) | Yes | Mapped correctly |
+
+**Verdict**: All nine GLiNER-specific extension fields are correctly identified and placed under `training:` in the schema, which matches the report's recommendation. The naming differs from upstream (e.g., `loss_alpha` vs `focal_loss_alpha`) but the mapping in `_launch_training` correctly translates between them.
+
+**Issue**: The default for `masking` in `training_cli.py` is `"none"` (line 166), while GLiNER's `TrainingArguments` defaults to `"global"` (trainer.py line 85). This mismatch means our CLI overrides GLiNER's default. This should be documented or aligned.
+
+---
+
+### LoRA Configuration
+
+#### `training_cli.py` LoRA schema (lines 184-191):
+
+| Field | Our default | Report recommendation | Status |
+|---|---|---|---|
+| `r` | 8 | `{8, 16, 32}` | OK |
+| `lora_alpha` | 16 | `~2r` (so 16 for r=8) | OK |
+| `lora_dropout` | 0.05 | `[0.05, 0.1]` | OK |
+| `bias` | `"none"` | `"none"` unless needed | OK |
+| `target_modules` | `["q_proj", "v_proj"]` | Model-dependent attention projections | OK |
+| `task_type` | `"TOKEN_CLS"` | - | OK |
+| `modules_to_save` | `None` | - | OK |
+| `init_lora_weights` | **MISSING** | `true` | MISSING from `_FIELD_SCHEMA` and `_apply_lora` |
+| `use_rslora` | **MISSING** | `false` | MISSING from `_FIELD_SCHEMA` and `_apply_lora` |
+| `fan_in_fan_out` | **MISSING** | `false` | MISSING from `_FIELD_SCHEMA` and `_apply_lora` |
+
+#### `config_cli.py` LoRA rules (`_LORA_RULES`, lines 103-116):
+
+The `config_cli.py` already has all three missing fields (`fan_in_fan_out`, `use_rslora`, `init_lora_weights`) in `_LORA_RULES`. **This means our two CLI modules are inconsistent**: `config_cli.py` validates 10 LoRA fields, while `training_cli.py` only validates 8.
+
+Additional discrepancy: `config_cli.py` defaults `target_modules` to `["query_proj", "value_proj"]` and `task_type` to `"FEATURE_EXTRACTION"`, while `training_cli.py` defaults `target_modules` to `["q_proj", "v_proj"]` and `task_type` to `"TOKEN_CLS"`. The `training_cli.py` defaults are more appropriate for typical use (DeBERTa uses `q_proj`/`v_proj`, and `TOKEN_CLS` is correct for NER), but the inconsistency is a defect.
+
+---
+
+### _launch_training Parameter Mapping
+
+This is the critical end-to-end analysis. For each field validated in `_FIELD_SCHEMA`, I trace whether it actually reaches `model.train_model()`.
+
+#### Fields validated AND correctly forwarded:
+
+| Schema field | Forwarded as | Line(s) |
+|---|---|---|
+| `training.num_steps` | `max_steps` | 1097 |
+| `training.scheduler_type` | `lr_scheduler_type` | 1098 |
+| `training.warmup_ratio` | `warmup_ratio` | 1099 |
+| `training.train_batch_size` | `per_device_train_batch_size` | 1101 |
+| `training.eval_batch_size` | `per_device_eval_batch_size` | 1102 |
+| `training.lr_encoder` | `learning_rate` | 1104 |
+| `training.lr_others` | `others_lr` | 1105 |
+| `training.weight_decay_encoder` | `weight_decay` | 1106 |
+| `training.weight_decay_other` | `others_weight_decay` | 1107 |
+| `training.max_grad_norm` | `max_grad_norm` | 1108 |
+| `training.optimizer` | `optim` | 1109 |
+| `training.loss_alpha` | `focal_loss_alpha` | 1111 |
+| `training.loss_gamma` | `focal_loss_gamma` | 1112 |
+| `training.loss_prob_margin` | `focal_loss_prob_margin` | 1113 |
+| `training.label_smoothing` | `label_smoothing` | 1114 |
+| `training.loss_reduction` | `loss_reduction` | 1115 |
+| `training.negatives` | `negatives` | 1116 |
+| `training.masking` | `masking` | 1117 |
+| `training.eval_every` | `save_steps` | 1119 |
+| `training.logging_steps` | `logging_steps` | 1120 |
+| `training.save_total_limit` | `save_total_limit` | 1121 |
+| `training.bf16` | `bf16` | 1123 |
+| `training.fp16` | `fp16` | 1124 |
+| `training.use_cpu` | `use_cpu` | 1126 |
+| `training.dataloader_num_workers` | `dataloader_num_workers` | 1127 |
+| `training.gradient_accumulation_steps` | `gradient_accumulation_steps` | 1131 |
+| `training.freeze_components` | `freeze_components` | 1094 (explicit param) |
+| `training.compile_model` | `compile_model` | 1095 (explicit param) |
+| `training.prev_path` | Used to select `from_pretrained` vs `from_config` | 1046-1052 |
+| `environment.report_to` | `report_to` | 1129 |
+
+#### Fields validated but NEVER forwarded (validated-but-not-forwarded):
+
+| Schema field | Line in schema | Impact |
+|---|---|---|
+| `training.size_sup` | 179 | **DEAD FIELD** - not consumed by GLiNER library anywhere. Grep across entire `gliner/` directory returns zero hits. This field exists in upstream config YAML examples but has no implementation. |
+| `training.shuffle_types` | 180 | **DEAD FIELD** - same as above. Not consumed anywhere in `gliner/`. |
+| `training.random_drop` | 181 | **DEAD FIELD** - same as above. Not consumed anywhere in `gliner/`. |
+| `training.dataloader_pin_memory` | 174 | **NOT FORWARDED** - validated in schema but never passed to `model.train_model()`. The Trainer would use its default (`True` from HF). Since our default is also `True` this accidentally works, but explicit values set by the user would be silently ignored. |
+| `training.dataloader_persistent_workers` | 175 | **NOT FORWARDED** - same issue. Default is `False`, which matches HF default, but user overrides are silently ignored. |
+| `training.dataloader_prefetch_factor` | 176 | **NOT FORWARDED** - same issue. |
+| `run.name` | 94 | Used for resume matching but not forwarded to `run_name` in TrainingArguments. W&B runs would not have a meaningful name. |
+| `run.description` | 95 | Not forwarded anywhere. |
+| `run.tags` | 96 | Not forwarded anywhere. |
+| `run.seed` | 97 | Used for `torch.manual_seed()` but NOT forwarded as `seed` to TrainingArguments. This means the Trainer's internal seed (for shuffling, etc.) may differ from the user's configured seed. |
+| `environment.push_to_hub` | 194 | Validated but never forwarded to TrainingArguments `push_to_hub`. |
+| `environment.hub_model_id` | 195 | Validated but never forwarded to TrainingArguments `hub_model_id`. |
+
+#### Fields forwarded but NOT validated in schema (forwarded-but-not-validated):
+
+None found -- all forwarded fields have schema entries. This is good.
+
+---
+
+### Missing Training Parameters
+
+The research report recommends these TrainingArguments fields which are completely absent from our schema AND our `_launch_training`:
+
+| Missing field | Category | Report tag | Impact |
+|---|---|---|---|
+| `num_train_epochs` | HF-TRAIN | Schedule | We only support `max_steps`. Users who prefer epoch-based training cannot express this. |
+| `auto_find_batch_size` | HF-TRAIN | Batch sizing | Useful for OOM recovery; HF Trainer natively supports this. |
+| `group_by_length` | HF-TRAIN | Batch sizing | Groups similar-length sequences; can significantly improve throughput. |
+| `adam_beta1` / `adam_beta2` / `adam_epsilon` | HF-TRAIN | Optimizer | Report explicitly lists these. Users cannot tune Adam hyperparams. |
+| `gradient_checkpointing` | HF-TRAIN | Precision/perf | Critical for large models. Completely absent. |
+| `torch_compile` | HF-TRAIN | Precision/perf | Report lists this as a TrainingArguments field; we have `compile_model` which calls `model.compile()` before training rather than using the Trainer's built-in `torch_compile` support. These are different code paths. |
+| `remove_unused_columns` | HF-TRAIN | Misc | Must be `false` for GLiNER's custom batch dictionaries. Report explicitly warns about this. Our code does not set it, meaning it defaults to `True` in HF Trainer, which **will silently drop batch columns and may cause training failures**. |
+| `evaluation_strategy` / `eval_steps` | HF-TRAIN | Evaluation | We set `save_steps` but never set `evaluation_strategy="steps"` or `eval_steps`. This means **evaluation never runs** unless the user passes it via... nothing -- there is no way to pass it through our CLI. |
+| `save_strategy` | HF-TRAIN | Saving | We set `save_steps` but never explicitly set `save_strategy="steps"`. HF defaults to `"steps"` so this accidentally works, but it's fragile. |
+| `run_name` | HF-TRAIN | Logging | Not forwarded from `run.name`. W&B runs get auto-generated names. |
+| `seed` | HF-TRAIN | Determinism | Not forwarded as a TrainingArguments field. Only used for `torch.manual_seed()`. |
+| `warmup_steps` | HF-TRAIN | Schedule | Sometimes preferred over `warmup_ratio`; absent. |
+| `push_to_hub` | HF-TRAIN | Hub | Validated in environment section but never wired to TrainingArguments. |
+| `hub_model_id` | HF-TRAIN | Hub | Same as above. |
+| `hub_strategy` | HF-TRAIN | Hub | Absent entirely. |
+| `hub_token` | HF-TRAIN | Hub | Validated but not forwarded. |
+| `resume_from_checkpoint` | HF-TRAIN | Resume | We have `--resume` CLI flag and checkpoint detection, but never pass the checkpoint path to `trainer.train(resume_from_checkpoint=...)`. |
+| `load_best_model_at_end` | HF-TRAIN | Model selection | Absent. |
+| `metric_for_best_model` | HF-TRAIN | Model selection | Absent. |
+| `deepspeed` / `fsdp` | HF-TRAIN | Distributed | Absent. |
+
+---
+
+### Loss Function Wiring
+
+**Focal loss**: Correctly wired. The chain is:
+1. `training_cli.py` validates `training.loss_alpha`, `training.loss_gamma`, `training.loss_prob_margin` (lines 160-162)
+2. `_launch_training` forwards them as `focal_loss_alpha`, `focal_loss_gamma`, `focal_loss_prob_margin` (lines 1111-1113)
+3. These flow through `create_training_args` (explicit params, lines 1008-1010) into `TrainingArguments` (trainer.py lines 79-81)
+4. `compute_loss` passes them to the model forward call as `alpha`, `gamma`, `prob_margin` (trainer.py lines 150-152)
+
+**Label smoothing**: Wired but fragile. The chain is:
+1. `training_cli.py` validates `training.label_smoothing` (line 163)
+2. `_launch_training` forwards it as `label_smoothing=float(...)` (line 1114)
+3. This is NOT an explicit parameter in `create_training_args` (line 1001-1027) -- it falls through to `**kwargs`
+4. It reaches `TrainingArguments` which has `label_smoothing` as a field (trainer.py line 82)
+5. `compute_loss` passes it to the model forward as `label_smoothing=self.args.label_smoothing` (trainer.py line 153)
+
+The pass-through via `**kwargs` works, but `label_smoothing` should be an explicit parameter in `create_training_args` for consistency and discoverability.
+
+**CRITICAL BUG -- `label_smoothing` name collision**: HF's standard `TrainingArguments` also has a `label_smoothing_factor` field. GLiNER's custom `TrainingArguments` adds its own `label_smoothing`. These are different mechanisms. If a user passes `label_smoothing_factor` through `**kwargs`, it would set the HF-level smoothing (in the Trainer's loss computation), while `label_smoothing` sets the GLiNER-level smoothing (in the model's forward). Both could be active simultaneously with potentially confusing results. This should be documented.
+
+**`loss_reduction`**: Correctly wired end-to-end.
+
+---
+
+### Parameter Flow Analysis
+
+The report's Mermaid diagram specifies four flows:
+
+```
+YAML -> model -> GLiNER.from_config()
+YAML -> training -> GLiNER.train_model() -> HF Trainer
+YAML -> peft -> Script applies PEFT to backbone
+YAML -> data -> Dataset loader -> Trainer
+```
+
+**Our implementation**:
+
+1. **YAML -> model -> GLiNER**: Correct. `_launch_training` passes `cfg["model"]` to `GLiNER.from_config(model_cfg)` (line 1052) or `GLiNER.from_pretrained(prev_path)` (line 1049).
+
+2. **YAML -> training -> Trainer**: Partially correct. Training fields are extracted from `cfg["training"]` and passed as kwargs to `model.train_model()`, which creates `TrainingArguments` and a `Trainer`. However, several validated training fields are dropped (see "validated-but-not-forwarded" above), and several important HF TrainingArguments are never populated.
+
+3. **YAML -> peft -> model**: Correct structure. `_apply_lora` (line 1059) applies PEFT to `model.model.token_rep_layer` before `train_model()` is called. However, only 7 of 10 PEFT config fields are forwarded (missing `init_lora_weights`, `use_rslora`, `fan_in_fan_out`).
+
+4. **YAML -> data -> Trainer**: Correct. Training data is loaded from `cfg["data"]["train_data"]` and passed directly to `model.train_model(train_dataset=...)`.
+
+**Missing flow**: The report specifies that `seed` should go to TrainingArguments for Trainer-level reproducibility. We only call `torch.manual_seed(seed)` and never forward it.
+
+**Missing flow**: The report specifies Hub-related fields flow through TrainingArguments. We validate them in the `environment` section but never forward them.
+
+---
+
+### LoRA _apply_lora Implementation
+
+**Location**: `training_cli.py` lines 1137-1183
+
+**Applying to `token_rep_layer`**: This is correct. GLiNER's architecture wraps the HuggingFace backbone inside `model.model.token_rep_layer`, which is the right target for PEFT wrapping. The code correctly checks `hasattr(model, "model") and hasattr(model.model, "token_rep_layer")` before applying.
+
+**Fields forwarded to `LoraConfig`**:
+
+| PEFT field | Forwarded? | Line |
+|---|---|---|
+| `r` | Yes | 1163 |
+| `lora_alpha` | Yes | 1164 |
+| `lora_dropout` | Yes | 1165 |
+| `bias` | Yes | 1166 |
+| `target_modules` | Yes | 1167 |
+| `task_type` | Yes | 1168 |
+| `modules_to_save` | Yes | 1169 |
+| `init_lora_weights` | **NO** | - |
+| `use_rslora` | **NO** | - |
+| `fan_in_fan_out` | **NO** | - |
+
+**Impact of missing fields**:
+- `init_lora_weights`: Controls initialization strategy. PEFT defaults to `True` (Kaiming). Missing this means users cannot use `"loftq"`, `"gaussian"`, or `"pissa"` initialization variants. Low impact for typical use.
+- `use_rslora`: Rank-Stabilized LoRA. When `True`, uses `lora_alpha / sqrt(r)` scaling instead of `lora_alpha / r`. This can significantly improve performance for higher ranks. Moderate impact.
+- `fan_in_fan_out`: Required when adapting `Conv1D` layers (used by GPT-2 style models). Since GLiNER typically uses BERT/DeBERTa encoders (which use `nn.Linear`), this is low impact but still a correctness gap.
+
+**Additional concern**: The `task_type` mapping (lines 1154-1159) only includes 4 options (`TOKEN_CLS`, `SEQ_CLS`, `CAUSAL_LM`, `SEQ_2_SEQ_LM`) but misses `FEATURE_EXTRACTION` which is what `config_cli.py` defaults to. If someone uses `config_cli.py` to validate and then `training_cli.py` to run, the default `FEATURE_EXTRACTION` task type would silently fall through to `TOKEN_CLS`.
+
+---
+
+### Concrete Recommendations
+
+1. **CRITICAL: Add `remove_unused_columns=False` to `_launch_training`**.
+   - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, line 1131 (inside `model.train_model()` call)
+   - GLiNER uses custom batch dictionaries. Without this, HF Trainer will drop columns not in the model's forward signature, causing silent data loss or crashes.
+
+2. **CRITICAL: Add `evaluation_strategy="steps"` and `eval_steps` to `_launch_training`**.
+   - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, line ~1119
+   - Without this, evaluation never runs during training even though we validate `eval_every`. Add:
+     ```python
+     evaluation_strategy="steps",
+     eval_steps=train_cfg["eval_every"],
+     ```
+
+3. **CRITICAL: Forward `run.seed` as TrainingArguments `seed`**.
+   - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, line ~1131
+   - Currently only `torch.manual_seed(seed)` is called. The Trainer has its own seed logic for data shuffling, dropout, etc.
+
+4. **HIGH: Forward `dataloader_pin_memory`, `dataloader_persistent_workers`, `dataloader_prefetch_factor` to `model.train_model()`**.
+   - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, line ~1127
+   - These are validated in `_FIELD_SCHEMA` (lines 174-176) but never forwarded. User-specified values are silently ignored.
+
+5. **HIGH: Add `gradient_checkpointing` to `_FIELD_SCHEMA` and forward it**.
+   - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, line ~176 (schema) and ~1131 (launch)
+   - Critical for training large backbones on limited GPU memory.
+
+6. **HIGH: Remove or clearly document dead fields `size_sup`, `shuffle_types`, `random_drop`**.
+   - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, lines 179-181
+   - These are validated and appear in `template.yaml` but are consumed by nothing in the GLiNER codebase. They mislead users into thinking they have an effect.
+
+7. **HIGH: Forward `run.name` as `run_name` in TrainingArguments**.
+   - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, line ~1129
+   - This enables meaningful W&B run names and checkpoint folder names.
+
+8. **MEDIUM: Add `init_lora_weights`, `use_rslora`, `fan_in_fan_out` to `_FIELD_SCHEMA` lora section and `_apply_lora`**.
+   - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, lines 184-191 (schema) and 1162-1169 (`_apply_lora`)
+   - Align with `config_cli.py`'s `_LORA_RULES` which already validates these three fields.
+   - Add `FEATURE_EXTRACTION` to the `task_map` in `_apply_lora` (line 1154).
+
+9. **MEDIUM: Add `label_smoothing` as an explicit parameter in upstream `create_training_args`**.
+   - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/gliner/model.py`, line ~1001
+   - Currently relies on `**kwargs` pass-through. Should be explicit for discoverability.
+
+10. **MEDIUM: Forward Hub-related fields from `environment` section to TrainingArguments**.
+    - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, line ~1131
+    - `push_to_hub`, `hub_model_id`, `hub_token` are validated but never reach the Trainer.
+
+11. **MEDIUM: Wire `--resume` to `resume_from_checkpoint` in Trainer**.
+    - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, line ~1090
+    - We detect checkpoints in `check_resume()` but never pass the checkpoint path to `trainer.train(resume_from_checkpoint=path)`.
+
+12. **MEDIUM: Add `adam_beta1`, `adam_beta2`, `adam_epsilon` to `_FIELD_SCHEMA`**.
+    - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, line ~155
+    - These are standard optimizer hyperparameters the report recommends.
+
+13. **LOW: Align `masking` default between `training_cli.py` (`"none"`) and GLiNER's `TrainingArguments` (`"global"`)**.
+    - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, line 166
+    - Document that our default intentionally overrides GLiNER's default, or change one to match the other.
+
+14. **LOW: Align LoRA defaults between `training_cli.py` and `config_cli.py`**.
+    - `training_cli.py`: `target_modules=["q_proj", "v_proj"]`, `task_type="TOKEN_CLS"`
+    - `config_cli.py`: `target_modules=["query_proj", "value_proj"]`, `task_type="FEATURE_EXTRACTION"`
+    - Standardize on one set of defaults.
+
+15. **LOW: Add `num_train_epochs` as an alternative to `num_steps`**.
+    - File: `/Users/arthrod/temp/T/GLiNER_testing/GLiNER/ptbr/training_cli.py`, schema
+    - Currently `training.num_steps` is REQUIRED. Some users prefer epoch-based training. Allow either `num_steps` or `num_train_epochs` with mutual exclusivity validation.


### PR DESCRIPTION
## Summary
- Four independent critical analysis reports comparing our `ptbr` config validation and training CLI against the deep research report's recommendations
- Each report was generated by a separate analysis agent examining upstream GLiNER source, our CLI code, and the report's specifications

## Key Findings

### Showstopper: YAML Format Incompatibility
- `config_cli.py` expects `gliner_config:` / `lora_config:` sections
- `training_cli.py` expects `model:` / `training:` / `lora:` sections
- **No single YAML file can satisfy both CLIs** — the `config` and `train` subcommands are mutually exclusive

### Standard Config (~35+ missing HF TrainingArguments fields)
- Hub integration validated but never forwarded to TrainingArguments
- W&B `run_name` not forwarded
- `fp16`, `dataloader_pin_memory/persistent_workers/prefetch_factor` validated but not forwarded
- `eval_every` conflates `save_steps` and `eval_steps`
- Missing: `gradient_checkpointing`, `resume_from_checkpoint`, `evaluation_strategy`, `num_train_epochs`, `deepspeed`/`fsdp`

### GLiNER Config
- Upstream `token-level` vs `token_level` bug in `GLiNERConfig.model_type` property
- `config_cli.py` defaults `decoder_mode` to `"span"` instead of upstream's `None`
- `training_cli.py` restricts `span_mode` to only 2 values vs 12 in `config_cli.py`
- `labels_encoder_config` and `labels_decoder_config` missing from both validators

### Training Parameters
- `remove_unused_columns` never set to `False` (will silently drop GLiNER batch columns)
- `evaluation_strategy`/`eval_steps` never forwarded — evaluation never runs
- 3 dead config fields (`size_sup`, `shuffle_types`, `random_drop`) mislead users
- LoRA missing `init_lora_weights`, `use_rslora`, `fan_in_fan_out`
- Resume flag validates but never passes checkpoint path to Trainer

## Reports
- `research/standard_config_report.md` — 20 concrete recommendations
- `research/gliner_config_report.md` — 18 concrete recommendations
- `research/training_parameters_report.md` — 15 concrete recommendations
- `research/integration_report.md` — 15 concrete recommendations

## Test plan
- [x] Coderabbit review of each report's findings against actual code
- [x] Verify cited line numbers and file references are accurate
- [x] Confirm upstream GLiNER source matches reported behavior