### PR TITLE
Add ptbr data preparation module with typer CLI

### DIFF
--- a/ptbr/__init__.py
+++ b/ptbr/__init__.py
@@ -13,10 +13,10 @@ CLI usage:
 
 from ptbr.data import (
     GLiNERData,
-    extract_labels,
-    load_data,
     prepare,
+    load_data,
     validate_data,
+    extract_labels,
 )
 
 __all__ = [

--- a/ptbr/__main__.py
+++ b/ptbr/__main__.py
@@ -1,4 +1,4 @@
-"""Central CLI entry point: python -m ptbr <command>
+"""Central CLI entry point: python -m ptbr <command>.
 
 Commands:
     data    Load, validate, and prepare GLiNER datasets
@@ -7,8 +7,8 @@ Commands:
 """
 
 import json
-from pathlib import Path
 from typing import Optional
+from pathlib import Path
 
 import typer
 
@@ -47,7 +47,7 @@ def data_cmd(
     ),
 ):
     """Load GLiNER data, validate, or generate label embeddings."""
-    from ptbr.data import extract_labels, load_data, validate_data
+    from ptbr.data import load_data, validate_data, extract_labels
 
     data = load_data(file_or_repo, text_column, ner_column, split=split)
     labels = extract_labels(data)
@@ -102,7 +102,7 @@ def config_cmd(
     method: str = typer.Option("span", help="GLiNER method: span, token, biencoder, decoder, relex."),
 ):
     """Validate a GLiNER training configuration YAML file."""
-    from ptbr.config_cli import load_and_validate_config, print_and_log_result
+    from ptbr.config_cli import print_and_log_result, load_and_validate_config
 
     result = load_and_validate_config(
         file, full_or_lora=full_or_lora, method=method, validate=validate,

--- a/ptbr/__main__.py
+++ b/ptbr/__main__.py
@@ -46,7 +46,20 @@ def data_cmd(
         "labels.json", help="Output path for extracted labels JSON."
     ),
 ):
-    """Load GLiNER data, validate, or generate label embeddings."""
+    """
+    Load GLiNER-formatted data, optionally validate it, and optionally generate and save label embeddings.
+    
+    Parameters:
+        file_or_repo (str): Local JSON/JSONL file path or HuggingFace dataset repository id.
+        text_column (str): Column name that contains tokenized text.
+        ner_column (str): Column name that contains NER annotations.
+        split (str): Dataset split to load (e.g., "train", "validation", "test").
+        validate (bool): If True, validate the loaded data against GLiNER native format and exit with code 1 on validation failure.
+        generate_label_embeddings (Optional[str]): If provided, name or path of a bi-encoder model used to encode label embeddings.
+        trust_remote_code (bool): If True, allow execution of custom code when loading remote models.
+        output_embeddings_path (str): File path where computed label embeddings will be saved (PyTorch format).
+        output_labels_path (str): File path where extracted labels will be saved (JSON, UTF-8).
+    """
     from ptbr.data import load_data, validate_data, extract_labels
 
     data = load_data(file_or_repo, text_column, ner_column, split=split)
@@ -101,7 +114,20 @@ def config_cmd(
     full_or_lora: str = typer.Option("full", help="Training mode: 'full' or 'lora'."),
     method: str = typer.Option("span", help="GLiNER method: span, token, biencoder, decoder, relex."),
 ):
-    """Validate a GLiNER training configuration YAML file."""
+    """
+    Validate a GLiNER training configuration YAML file and optionally print a rich validation report.
+    
+    If `validate` is True, prints and logs a detailed validation report for the provided config file. Exits the process with code 1 when the validation report is not valid.
+    
+    Parameters:
+        file (str): Path to the YAML configuration file.
+        validate (bool): When True, run full validation and emit a rich report.
+        full_or_lora (str): Training mode, either "full" or "lora".
+        method (str): GLiNER method to validate for (e.g., "span", "token", "biencoder", "decoder", "relex").
+    
+    Raises:
+        typer.Exit: Exits with code 1 if the configuration validation fails.
+    """
     from ptbr.config_cli import print_and_log_result, load_and_validate_config
 
     result = load_and_validate_config(

--- a/ptbr/config_cli.py
+++ b/ptbr/config_cli.py
@@ -1,4 +1,4 @@
-"""GLiNER fine-tuning configuration validator and CLI.
+r"""GLiNER fine-tuning configuration validator and CLI.
 
 Usage as CLI (via Typer):
     python -m ptbr.config_cli --file config.yaml --validate \\
@@ -15,15 +15,15 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass, field
-from datetime import datetime
+from typing import Any, Dict, List, Tuple, Literal, Optional
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from datetime import datetime
+from dataclasses import field, dataclass
 
 import yaml
-from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+from rich.console import Console
 
 from gliner.config import GLiNERConfig
 
@@ -691,8 +691,11 @@ def print_and_log_result(
 # ============================================================================
 
 def _build_app():
-    """Build the Typer app. Imported lazily so the module works without typer
-    when used purely as a library (typer is only needed for CLI execution)."""
+    """Build the Typer app.
+
+    Imported lazily so the module works without typer
+    when used purely as a library (typer is only needed for CLI execution).
+    """
     import typer
 
     app = typer.Typer(

--- a/ptbr/config_cli.py
+++ b/ptbr/config_cli.py
@@ -691,10 +691,13 @@ def print_and_log_result(
 # ============================================================================
 
 def _build_app():
-    """Build the Typer app.
-
-    Imported lazily so the module works without typer
-    when used purely as a library (typer is only needed for CLI execution).
+    """
+    Constructs and returns a Typer CLI application for validating and inspecting GLiNER fine-tuning YAML configurations.
+    
+    The app exposes a `main` command that loads a YAML config file, runs validation (optionally printing a rich summary and saving a log), and exits with a nonzero code on validation failure.
+    
+    Returns:
+        typer.Typer: A configured Typer application exposing the `main` command.
     """
     import typer
 

--- a/ptbr/data.py
+++ b/ptbr/data.py
@@ -5,10 +5,10 @@ Compatible with all model variants: span, token, bi-encoder, decoder,
 relation extraction (relex), and multitask pipelines.
 """
 
-import json
 import os
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Tuple
+import json
+from typing import Any, Dict, List, Tuple, Optional
+from dataclasses import field, dataclass
 
 
 @dataclass
@@ -35,7 +35,7 @@ def load_data(
     Extra columns (relations, ner_negatives, ner_labels, etc.) are preserved.
     """
     if os.path.exists(file_or_repo):
-        with open(file_or_repo, "r", encoding="utf-8") as f:
+        with open(file_or_repo, encoding="utf-8") as f:
             if file_or_repo.endswith(".jsonl"):
                 raw = [json.loads(line) for line in f if line.strip()]
             else:

--- a/ptbr/data.py
+++ b/ptbr/data.py
@@ -29,10 +29,22 @@ def load_data(
     ner_column: str = "ner",
     split: str = "train",
 ) -> List[Dict[str, Any]]:
-    """Load data from a local JSON file or a HuggingFace dataset repo.
-
-    Columns are mapped to GLiNER's native keys (tokenized_text, ner).
-    Extra columns (relations, ner_negatives, ner_labels, etc.) are preserved.
+    """
+    Load dataset from a local JSON/JSONL file or a HuggingFace dataset repository and map columns to GLiNER's native format.
+    
+    If a local path is provided, the file is read as JSONL when it ends with ".jsonl" or as JSON otherwise. If the provided column names differ from GLiNER's native keys, the specified text_column and ner_column are remapped to "tokenized_text" and "ner" respectively; other fields are preserved. If a HuggingFace dataset identifier is provided, the specified split is loaded and the dataset columns are similarly remapped.
+    
+    Parameters:
+        file_or_repo (str): Local filesystem path or HuggingFace dataset identifier.
+        text_column (str): Name of the column containing tokenized text in the source data (defaults to "tokenized_text").
+        ner_column (str): Name of the column containing NER spans in the source data (defaults to "ner").
+        split (str): Dataset split to load when using a HuggingFace dataset (defaults to "train").
+    
+    Returns:
+        List[Dict[str, Any]]: A list of records in GLiNER native format where each record contains at least the keys "tokenized_text" and "ner"; additional source fields are preserved.
+    
+    Raises:
+        ValueError: If the required text or ner columns are missing in the provided local file or dataset split.
     """
     if os.path.exists(file_or_repo):
         with open(file_or_repo, encoding="utf-8") as f:

--- a/ptbr/tests/generate_noisy_jsonl.py
+++ b/ptbr/tests/generate_noisy_jsonl.py
@@ -9,11 +9,11 @@ Creates:
     Prints a full validation report at the end.
 """
 
+import sys
 import copy
 import json
-import random
-import sys
 import time
+import random
 from pathlib import Path
 
 # Ensure repo root is importable

--- a/ptbr/tests/test_config_cli.py
+++ b/ptbr/tests/test_config_cli.py
@@ -3,25 +3,22 @@
 from __future__ import annotations
 
 import json
-import textwrap
 from pathlib import Path
 
-import pytest
 import yaml
+import pytest
 
+from gliner.config import GLiNERConfig
 from ptbr.config_cli import (
-    GLiNERConfigResult,
+    _LORA_RULES,
+    _GLINER_RULES,
     ValidationReport,
     _coerce_type,
     _validate_section,
-    _validate_cross_constraints,
-    _GLINER_RULES,
-    _LORA_RULES,
-    load_and_validate_config,
     print_and_log_result,
+    load_and_validate_config,
+    _validate_cross_constraints,
 )
-from gliner.config import GLiNERConfig
-
 
 # ============================================================================
 # Helpers
@@ -162,7 +159,7 @@ class TestCoerceType:
 class TestValidateSection:
     def test_required_field_missing_errors(self):
         report = ValidationReport()
-        result = _validate_section({}, _GLINER_RULES, "gliner_config", report)
+        _validate_section({}, _GLINER_RULES, "gliner_config", report)
         # model_name is REQUIRED
         errors = [i for i in report.errors if "model_name" in i.field]
         assert len(errors) == 1
@@ -171,7 +168,7 @@ class TestValidateSection:
     def test_default_fields_produce_warnings(self):
         report = ValidationReport()
         data = {"model_name": "some-model"}
-        result = _validate_section(data, _GLINER_RULES, "gliner_config", report)
+        _validate_section(data, _GLINER_RULES, "gliner_config", report)
         # Many fields should get defaults → warnings
         warning_fields = {i.field.split(".")[-1] for i in report.warnings}
         assert "name" in warning_fields
@@ -182,7 +179,7 @@ class TestValidateSection:
     def test_fully_specified_no_warnings(self):
         report = ValidationReport()
         data = _full_gliner_config()
-        result = _validate_section(data, _GLINER_RULES, "gliner_config", report)
+        _validate_section(data, _GLINER_RULES, "gliner_config", report)
         # Only _attn_implementation should produce a warning since it's None and default is None
         # (None default → no warning)
         non_attn_warnings = [w for w in report.warnings if "_attn_implementation" not in w.field]

--- a/ptbr/tests/test_config_cli_aliases.py
+++ b/ptbr/tests/test_config_cli_aliases.py
@@ -6,10 +6,10 @@ before importing ``ptbr.config_cli``.
 
 from __future__ import annotations
 
-import importlib
 import sys
-from pathlib import Path
+import importlib
 from types import ModuleType
+from pathlib import Path
 
 import yaml
 

--- a/ptbr/tests/test_main_cli.py
+++ b/ptbr/tests/test_main_cli.py
@@ -1,9 +1,9 @@
 """Tests for top-level ptbr CLI wiring."""
 
-import importlib
 import sys
-from pathlib import Path
+import importlib
 from types import ModuleType, SimpleNamespace
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest

--- a/ptbr/tests/test_train_py.py
+++ b/ptbr/tests/test_train_py.py
@@ -2,12 +2,11 @@
 
 from __future__ import annotations
 
-import importlib.util
 import sys
-from pathlib import Path
+import importlib.util
 from types import ModuleType, SimpleNamespace
+from pathlib import Path
 from unittest.mock import patch
-
 
 ROOT = Path(__file__).resolve().parents[2]
 TRAIN_PY = ROOT / "train.py"

--- a/ptbr/tests/test_training_cli.py
+++ b/ptbr/tests/test_training_cli.py
@@ -281,13 +281,12 @@ class TestSemanticChecks:
 
     def test_positive_num_steps(self, valid_cfg: dict) -> None:
         """
-        Checks that semantic validation reports an error when training.num_steps is not positive.
-
-        Sets training.num_steps to 0 on the provided configuration, runs semantic_checks,
-        and asserts that an error referencing "num_steps" is present in the ValidationResult.
-
+        Verify semantic validation reports an error when training.num_steps is not greater than zero.
+        
+        This test sets `training.num_steps` to 0 and asserts that `ValidationResult` contains an error mentioning "num_steps".
+        
         Parameters:
-            valid_cfg (dict): A baseline valid configuration dictionary used for the test.
+            valid_cfg (dict): Baseline valid configuration used by the test.
         """
         valid_cfg["training"]["num_steps"] = 0
         result = ValidationResult()

--- a/ptbr/tests/test_training_cli.py
+++ b/ptbr/tests/test_training_cli.py
@@ -4,29 +4,29 @@ from __future__ import annotations
 
 import os
 import sys
-from pathlib import Path
 import types
 from types import ModuleType
+from pathlib import Path
 from unittest import mock
 
-import pytest
 import yaml
+import pytest
 from typer.testing import CliRunner
 
 from ptbr.training_cli import (
-    _apply_lora,
-    _check_type,
+    ValidationResult,
+    app,
     _deep_get,
     _deep_set,
-    _launch_training,
-    app,
-    check_huggingface,
+    _apply_lora,
+    _check_type,
     check_wandb,
     check_resume,
     print_summary,
     semantic_checks,
     validate_config,
-    ValidationResult,
+    _launch_training,
+    check_huggingface,
 )
 
 runner = CliRunner()
@@ -283,7 +283,8 @@ class TestSemanticChecks:
         """
         Checks that semantic validation reports an error when training.num_steps is not positive.
 
-        Sets training.num_steps to 0 on the provided configuration, runs semantic_checks, and asserts that an error referencing "num_steps" is present in the ValidationResult.
+        Sets training.num_steps to 0 on the provided configuration, runs semantic_checks,
+        and asserts that an error referencing "num_steps" is present in the ValidationResult.
 
         Parameters:
             valid_cfg (dict): A baseline valid configuration dictionary used for the test.
@@ -552,7 +553,8 @@ class TestCLI:
         """
         Allow validation to run when `--resume` is supplied without `--output-folder`.
 
-        Invokes the CLI with `--validate` and `--resume` for the provided config file and asserts the command exits with code 0.
+        Invokes the CLI with `--validate` and `--resume` for the provided config file
+        and asserts the command exits with code 0.
         """
         result = runner.invoke(app, [str(cfg_file), "--validate", "--resume"])
         # validate-only doesn't check resume (no output folder)

--- a/ptbr/tests/test_validation.py
+++ b/ptbr/tests/test_validation.py
@@ -40,6 +40,15 @@ def report(name, passed, detail=""):
 
 
 def load_mock(filename):
+    """
+    Load and parse a JSON mock file from the test mocks directory.
+    
+    Parameters:
+        filename (str): Name of the mock file relative to the global MOCKS directory.
+    
+    Returns:
+        obj: The parsed JSON content (typically a dict or list) from the specified file.
+    """
     path = MOCKS / filename
     with open(path, encoding="utf-8") as f:
         return json.load(f)

--- a/ptbr/tests/test_validation.py
+++ b/ptbr/tests/test_validation.py
@@ -11,17 +11,17 @@ Usage:
     python ptbr/tests/test_validation.py
 """
 
-import importlib.util
-import json
 import os
 import re
-import subprocess
 import sys
+import json
 import tempfile
+import subprocess
+import importlib.util
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from ptbr import GLiNERData, extract_labels, load_data, prepare, validate_data
+from ptbr import GLiNERData, prepare, load_data, validate_data
 
 MOCKS = Path(__file__).resolve().parent / "mocks"
 PASS = 0
@@ -41,7 +41,7 @@ def report(name, passed, detail=""):
 
 def load_mock(filename):
     path = MOCKS / filename
-    with open(path, "r", encoding="utf-8") as f:
+    with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -63,7 +63,7 @@ def test_sample_data():
     if not sample.exists():
         report("examples/sample_data.json", False, "file not found")
         return
-    with open(sample, "r", encoding="utf-8") as f:
+    with open(sample, encoding="utf-8") as f:
         data = json.load(f)
     ok, errs = validate_data(data)
     report("examples/sample_data.json passes", ok, f"{len(data)} entries, {len(errs)} errors")

--- a/ptbr/training_cli.py
+++ b/ptbr/training_cli.py
@@ -65,10 +65,12 @@ _file_handler: Optional[logging.FileHandler] = None
 
 def _attach_file_handler(log_path: Path) -> None:
     """
-    Attach a file log handler that writes logs to the given path, replacing any previously attached file handler.
-
+    Attach a file-based logging handler writing to log_path, replacing any previously attached file handler.
+    
+    The handler opens the file in write mode with UTF-8 encoding, logs messages at DEBUG level, and uses the formatter "%(asctime)s | %(levelname)-8s | %(message)s". Parent directories for log_path will be created if they do not exist.
+    
     Parameters:
-        log_path (Path): Destination file path for the log; parent directories will be created if missing.
+    	log_path (Path): Destination file path for the log file; parent directories will be created if missing.
     """
     global _file_handler
     if _file_handler is not None:
@@ -228,18 +230,15 @@ def _deep_get(d: dict, dotted_key: str) -> tuple[bool, Any]:
 
 def _deep_set(d: dict, dotted_key: str, value: Any) -> None:
     """
-    Set a value in a nested dictionary at the location specified by a dotted key.
-
-    Creates intermediate dictionaries as needed.
-
+    Set a value in a nested dictionary using a dotted path, creating intermediate mappings as needed.
+    
     Parameters:
         d (dict): Dictionary to modify in place.
-        dotted_key (str): Dotted path to the target key (e.g., "section.sub.key").
+        dotted_key (str): Dotted path to the target key (e.g., "section.sub.key"); intermediate mappings will be created when missing.
         value (Any): Value to assign to the final key.
-
-    Notes:
-        - Intermediate dictionaries are created when a path segment is missing.
-        - The final key's value is overwritten if it already exists.
+    
+    Raises:
+        ValueError: If a parent segment along the path exists but is not a mapping.
     """
     keys = dotted_key.split(".")
     current = d
@@ -262,13 +261,13 @@ def _deep_set(d: dict, dotted_key: str, value: Any) -> None:
 
 def _type_name(t: type | tuple) -> str:
     """
-    Return a human-readable name for a type or a tuple of types.
-
+    Get a human-readable name for a type or a union of types.
+    
     Parameters:
         t (type | tuple): A type object or a tuple of type objects.
-
+    
     Returns:
-        str: The type's __name__ or the joined type names separated by " | ".
+        type_name (str): The type's name, or the names joined with " | " for a tuple.
     """
     if isinstance(t, tuple):
         return " | ".join(x.__name__ for x in t)
@@ -277,18 +276,17 @@ def _type_name(t: type | tuple) -> str:
 
 def _check_type(value: Any, expected: type | tuple[type, ...]) -> bool:
     """
-    Perform a relaxed type check allowing integers where floats are expected.
-
+    Determine whether a value matches the expected type constraints, treating integers as valid where floating-point values are allowed.
+    
     Parameters:
-        value (Any): The value to test.
-        expected (type | tuple[type, ...]): A type or tuple of types that `value` should conform to.
-
+        value (Any): The value to validate.
+        expected (type | tuple[type, ...]): A type or tuple of types that `value` should match.
+    
     Returns:
-        bool: `True` if `value` matches any of the `expected` types
-            (treating `int` as compatible with `float`), `False` otherwise.
-
+        bool: `True` if `value` matches any of the `expected` types (an `int` is accepted when `float` is expected), `False` otherwise.
+    
     Notes:
-        - A `bool` value is not considered a match unless `bool` is explicitly included in `expected`.
+        A `bool` is treated as a distinct type and will not match unless `bool` is explicitly included in `expected`.
     """
     if isinstance(expected, tuple):
         types = expected
@@ -335,13 +333,14 @@ class ValidationResult:
 
     def __init__(self) -> None:
         """
-        Initialize a ValidationResult with empty collections for errors, warnings, and per-field info.
-
+        Create an empty ValidationResult used to collect configuration validation outcomes.
+        
         Attributes:
-            errors (list[str]): Collected error messages.
-            warnings (list[str]): Collected warning messages.
-            info (list[tuple[str, str, Any]]): Per-field tuples of (key, status, value)
-                where status is one of "OK", "DEFAULT", or "ERROR".
+            errors (list[str]): Collected error messages encountered during validation.
+            warnings (list[str]): Collected warning messages about non-fatal issues or defaults applied.
+            info (list[tuple[str, str, Any]]): Per-field records as tuples (key, status, value) where
+                status is one of "OK", "DEFAULT", or "ERROR", and value is the (possibly redacted)
+                value observed or the default filled in.
         """
         self.errors: list[str] = []
         self.warnings: list[str] = []
@@ -431,12 +430,14 @@ def _check_extra_keys(
     prefix: str = "",
 ) -> None:
     """
-    Record warnings for configuration keys that are not defined in the schema.
-
+    Warn about configuration keys that are not defined in the schema.
+    
+    Scans a configuration subtree and appends a warning to the provided ValidationResult for every dotted key not present in the known schema set. Warnings describe the full dotted key path that will be ignored.
+    
     Parameters:
-        cfg (dict): Configuration mapping (or subtree) to inspect for unknown keys.
-        known (set[str]): Set of dotted keys that are recognized by the schema.
-        result (ValidationResult): ValidationResult to which warnings will be appended for any extra keys found.
+        cfg (dict): Configuration mapping or nested subtree to inspect.
+        known (set[str]): Set of valid dotted keys defined by the schema.
+        result (ValidationResult): Collector to which warning messages will be appended.
         prefix (str): Dotted-key prefix used when traversing nested dictionaries to build full key names.
     """
     for key, value in cfg.items():
@@ -469,19 +470,18 @@ _VALID_ATTN_IMPL = {"eager", "sdpa", "flash_attention_2"}
 
 def semantic_checks(cfg: dict, result: ValidationResult) -> None:
     """
-    Perform cross-field semantic and enum validations on the resolved configuration.
-
-    This routine inspects related configuration fields and appends entries to the provided ValidationResult:
-    - Validates enumerated fields and records enum-related errors/warnings.
-    - Ensures dependent fields are present when required (e.g., decoder_mode when labels_decoder is set).
-    - Requires a WandB project when reporting includes `wandb`.
-    - Requires a Hugging Face Hub model id when `push_to_hub` is enabled.
-    - Enforces that certain numeric training parameters are greater than zero.
-    - Ensures `training.bf16` and `training.fp16` are not both enabled.
-
+    Run cross-field semantic validations and enum checks on a resolved configuration and record findings in the provided ValidationResult.
+    
+    Performs:
+    - Enum validation for several configuration keys and optional enums when present.
+    - Presence checks for fields that are required by other fields (e.g., decoder_mode when labels_decoder is set).
+    - Validation that reporting to WandB includes a wandb_project and that pushing to the Hub includes a hub_model_id.
+    - Numeric sanity checks: ensures selected numeric fields are greater than zero and that bounded numeric fields fall inside their allowed ranges.
+    - Mutual-exclusion check preventing both `training.bf16` and `training.fp16` from being enabled simultaneously.
+    
     Parameters:
         cfg (dict): Resolved configuration dictionary to validate.
-        result (ValidationResult): Collector for errors, warnings, and info updated by this function.
+        result (ValidationResult): Collector to which errors, warnings, and informational entries are appended.
     """
     _check_enum(cfg, result, "model.span_mode", _VALID_SPAN_MODES)
     _check_enum(cfg, result, "training.scheduler_type", _VALID_SCHEDULERS)
@@ -563,18 +563,17 @@ def semantic_checks(cfg: dict, result: ValidationResult) -> None:
 def _check_enum(
     cfg: dict, result: ValidationResult, key: str, valid: set[str]
 ) -> None:
-    """Check that a configuration value is one of an allowed set of string values and record an error if not.
-
+    """
+    Validate that the configuration field at `key` (dotted path) is either `None` or one of the allowed string values, and record an error if it is not.
+    
     Parameters:
         cfg (dict): Configuration mapping to read the dotted `key` from.
-        result (ValidationResult): Accumulates validation errors and warnings;
-            an error is appended here when the value is invalid.
+        result (ValidationResult): Collector for validation errors and warnings; an error is appended here when the value is invalid.
         key (str): Dotted path into `cfg` (e.g., "model.span_mode") to validate.
         valid (set[str]): Allowed string values for the configuration key.
-
+    
     Behavior:
-        If the key exists in `cfg` with a non-None value that is not a member of `valid`,
-        an error message describing the invalid value is appended to `result.errors` and also logged.
+        If the key exists in `cfg` with a non-None value that is not a member of `valid`, an error message is appended to `result.errors` and logged.
     """
     _, val = _deep_get(cfg, key)
     if val is not None and val not in valid:
@@ -610,13 +609,13 @@ def _check_data_paths(cfg: dict, config_dir: Path, result: ValidationResult) -> 
 
 def check_huggingface(cfg: dict, result: ValidationResult) -> None:
     """
-    Check HuggingFace credentials and record any authentication errors.
-
-    If cfg["environment"]["push_to_hub"] is false, this function does nothing.
-    If push_to_hub is true it looks for a token in cfg["environment"]["hf_token"] or the HF_TOKEN environment variable;
-    if no token is found an error is recorded on result. When a token is present the function queries the HuggingFace
-    whoami API: on success it logs the authenticated username; on any non-200 response or exception it appends an error
-    message to result describing the failure.
+    Validate HuggingFace authentication when repository upload is requested and record any failures in `result`.
+    
+    If `environment.push_to_hub` is true, the function looks for a token in `environment.hf_token` or the `HF_TOKEN` environment variable; if no token is found it appends an error to `result`. When a token is present the function calls the HuggingFace whoami API and on success logs the authenticated username; on non-200 responses or exceptions it appends an error describing the failure to `result`.
+    
+    Parameters:
+        cfg (dict): Resolved configuration dictionary.
+        result (ValidationResult): Collector for validation errors, warnings, and info where authentication failures will be recorded.
     """
     _, push = _deep_get(cfg, "environment.push_to_hub")
     if not push:
@@ -653,17 +652,17 @@ def check_huggingface(cfg: dict, result: ValidationResult) -> None:
 
 
 def check_wandb(cfg: dict, result: ValidationResult) -> None:
-    """Verify WandB credentials when WandB reporting is enabled.
-
-    If `environment.report_to` in `cfg` includes "wandb" or "all", this function looks for an API key
-    in `cfg["environment"]["wandb_api_key"]` or the `WANDB_API_KEY` environment variable and performs a
-    GraphQL request to WandB to validate the key. On success it logs the authenticated username; on
-    failure it appends a descriptive error to `result.errors` and logs the failure.
-
+    """
+    Validate Weights & Biases credentials when WandB reporting is enabled.
+    
+    If `environment.report_to` in `cfg` includes "wandb" or "all", this function ensures an API key is provided
+    (either `cfg["environment"]["wandb_api_key"]` or the `WANDB_API_KEY` environment variable) and verifies it
+    by calling the WandB API. On verification failure or if no key is found, a descriptive error is appended to
+    `result.errors`; on success the authenticated username is logged.
+    
     Parameters:
         cfg (dict): Resolved configuration dictionary.
-        result (ValidationResult): ValidationResult instance to record errors and warnings; this function
-            mutates `result.errors` on failure.
+        result (ValidationResult): ValidationResult instance used to record validation errors and warnings.
     """
     _, report = _deep_get(cfg, "environment.report_to")
     if report not in ("wandb", "all"):
@@ -708,18 +707,18 @@ def check_wandb(cfg: dict, result: ValidationResult) -> None:
 
 def check_resume(cfg: dict, output_folder: Path, result: ValidationResult) -> None:
     """
-    Verify the output folder contains a compatible checkpoint for resuming a run.
-
-    Performs these validations and appends errors to `result` when they fail:
-    - Ensures `run.name` exists in `cfg`.
-    - Ensures at least one `checkpoint-*` directory exists inside `output_folder`.
-    - Ensures a saved `config.yaml` exists in `output_folder`.
-    - Ensures the saved config's `run.name` matches `cfg["run"]["name"]`.
-
+    Validate that the given output folder contains a compatible checkpoint and saved configuration for resuming the run.
+    
+    Performs these checks and records errors on `result` when they fail:
+    - `cfg` must contain `run.name`.
+    - `output_folder` must contain at least one `checkpoint-*` directory.
+    - `output_folder/config.yaml` must exist.
+    - The saved config's `run.name` must match `cfg["run"]["name"]`.
+    
     Parameters:
-        cfg (dict): The resolved configuration dictionary to validate (expects `run.name`).
+        cfg (dict): Resolved configuration dictionary (expects `run.name` to identify the run).
         output_folder (Path): Path to the run's output directory to inspect for checkpoints and saved config.
-        result (ValidationResult): ValidationResult instance to record errors and warnings.
+        result (ValidationResult): ValidationResult instance where errors and warnings will be appended.
     """
     _, run_name = _deep_get(cfg, "run.name")
     if not run_name:
@@ -767,14 +766,15 @@ def check_resume(cfg: dict, output_folder: Path, result: ValidationResult) -> No
 
 def print_summary(result: ValidationResult) -> str:
     """
-    Display a formatted validation summary to the console.
-
+    Render and print a Rich-formatted configuration validation summary to the console and return a plain-text version.
+    
+    Prints a colored table of per-field statuses and panels for warnings and errors to the module Rich console (stderr). Also builds and returns a plain-text, multi-line summary suitable for saving to a file.
+    
     Parameters:
-        result (ValidationResult): ValidationResult containing per-field info tuples
-            (key, status, value), plus lists of warnings and errors.
-
+        result (ValidationResult): Aggregated validation outcome containing per-field info tuples (key, status, value), plus lists of warnings and errors.
+    
     Returns:
-        str: Plain-text multi-line summary of the validated fields, warnings, and errors suitable for saving to a file.
+        str: Plain-text multi-line summary describing each checked field, followed by warnings and errors counts and details.
     """
     table = Table(
         title="Configuration Validation Summary",
@@ -1003,14 +1003,14 @@ def _launch_training(
     config_dir: Path,
 ) -> None:
     """
-    Prepare the GLiNER model and start training based on the resolved configuration.
-
+    Prepare model, datasets, and environment then start GLiNER training according to the resolved configuration.
+    
     Parameters:
-        cfg: Resolved configuration dictionary containing keys for "run", "model",
+        cfg (dict): Resolved configuration dictionary containing sections "run", "model",
             "data", "training", "lora", and "environment".
-        output_folder: Directory where training outputs and checkpoints will be written.
-        resume: Resume flag from the CLI; preserved for compatibility.
-        config_dir: Directory of the config file, used to resolve relative data paths.
+        output_folder (Path): Directory where training outputs and checkpoints will be written.
+        resume (bool): If true, attempt to resume from the latest checkpoint found in output_folder.
+        config_dir (Path): Directory of the configuration file; used to resolve relative dataset paths.
     """
     logger.info("Preparing training run ...")
 
@@ -1167,16 +1167,16 @@ def _launch_training(
 
 def _apply_lora(model: Any, lora_cfg: dict) -> None:
     """
-    Apply a LoRA adapter to the model's HuggingFace backbone (PreTrainedModel).
-
+    Apply a LoRA adapter to the model's HuggingFace backbone in-place.
+    
     Parameters:
-        model (Any): Model object expected to contain attribute
-            `model.token_rep_layer.bert_layer.model` (the HF PreTrainedModel backbone);
-            this function replaces that attribute in-place with a PEFT-wrapped model when found.
-        lora_cfg (dict): LoRA configuration mapping with required keys `r`, `lora_alpha`,
-            `lora_dropout`, `bias`, and `target_modules`; optional keys include `task_type`
-            and `modules_to_save`.
-
+        model (Any): Model expected to contain a HuggingFace PreTrainedModel backbone at
+            `model.model.token_rep_layer.bert_layer.model`. When found, that attribute is
+            replaced with a PEFT-wrapped model.
+        lora_cfg (dict): LoRA configuration with required keys `r`, `lora_alpha`,
+            `lora_dropout`, `bias`, and `target_modules`. Optional keys include
+            `task_type` and `modules_to_save`.
+    
     Raises:
         typer.Exit: If the `peft` package is not installed.
     """

--- a/research/integration_report.md
+++ b/research/integration_report.md
@@ -27,12 +27,16 @@ However, **several Priority 2 and Priority 3 issues remain open**, including dea
 
 **Main tests (tests/):** 173 passed, 33 failed, 54 errors (pre-existing issues unrelated to ptbr; mostly tokenizer/processor incompatibilities with current transformers version).
 
-**Static analysis (ruff):** 52 findings in ptbr/:
-- 4 unused imports (F401) in test files and `training_cli.py` (`sys`, `time`)
-- 3 unused variable assignments (F841) in `test_config_cli.py`
-- ~30 whitespace/formatting issues (W293 trailing whitespace in docstrings, E101 mixed tabs/spaces)
-- 5 lines exceeding 120 chars (E501) in docstrings and test docstrings
-- No logic bugs, no security issues, no undefined names
+**Static analysis (ruff):** 96 findings in ptbr/ (after cleanup of F401, F841, W293, E101, E501, D-series, B904 issues):
+- 43 `print` statements (T201) in test utilities and `generate_noisy_jsonl.py` (expected for CLI tools)
+- 20 f-string logging (G004) in `training_cli.py` (style preference, no functional impact)
+- 17 non-top-level imports (PLC0415) (intentional lazy-loading pattern)
+- 4 global statements (PLW0603) (intentional module-level caching)
+- 3 Typer default-call conventions (B008) (standard Typer usage)
+- 3 unused loop variables (B007) in `config_cli.py`
+- 2 unused function arguments (ARG001) in Typer callbacks
+- 4 minor style items (SIM102, PLR0911, TC003, PLW2901)
+- No ruff-reported undefined names or security-rule violations
 
 ---
 
@@ -254,17 +258,22 @@ Items from the original report that are still open:
 
 ### Static Analysis Findings
 
-52 ruff findings, all low-severity:
+96 ruff findings remaining after cleanup (all intentional patterns or low-severity style items):
 
 | Category | Count | Files | Severity |
 |---|---|---|---|
-| Unused imports (F401) | 4 | `training_cli.py` (sys, time), `test_config_cli.py`, `test_validation.py` | Low — dead code |
-| Unused variables (F841) | 3 | `test_config_cli.py` | Low — test readability |
-| Trailing whitespace (W293) | ~25 | `training_cli.py` docstrings | Cosmetic |
-| Mixed tabs/spaces (E101) | ~10 | `training_cli.py` docstrings | Cosmetic |
-| Line too long (E501) | 5 | `training_cli.py`, `test_training_cli.py` | Cosmetic |
+| Print statements (T201) | 43 | `generate_noisy_jsonl.py`, `test_validation.py` | Expected — CLI/test output |
+| F-string logging (G004) | 20 | `training_cli.py` | Style preference — no functional impact |
+| Non-top-level imports (PLC0415) | 17 | `__main__.py`, `training_cli.py`, `config_cli.py`, `data.py`, tests | Intentional — lazy-loading pattern |
+| Global statements (PLW0603) | 4 | `__main__.py`, `training_cli.py`, `test_validation.py` | Intentional — module-level caching |
+| Typer defaults (B008) | 3 | `config_cli.py`, `training_cli.py` | Expected — standard Typer convention |
+| Unused loop variables (B007) | 3 | `config_cli.py` | Low — cosmetic |
+| Unused function arguments (ARG001) | 2 | `config_cli.py` | Expected — Typer callback signatures |
+| Other style (SIM102, PLR0911, TC003, PLW2901) | 4 | Various | Low — cosmetic |
 
-No logic errors, undefined names, or security concerns were found by static analysis.
+**Previously fixed (this cleanup round):** Removed 2 unused imports (F401) in `training_cli.py` (`sys`, `time`), 1 unused import in `test_config_cli.py` (`textwrap`), 1 unused import in `test_config_cli.py` (`GLiNERConfigResult`), 1 unused import in `test_validation.py` (`extract_labels`), 3 unused variable assignments (F841) in `test_config_cli.py`, ~26 trailing whitespace issues (W293), ~10 mixed tabs/spaces (E101), 6 lines exceeding 120 chars (E501), 2 docstring formatting issues (D205/D209/D206), 1 missing raw docstring prefix (D301), 1 missing period in module docstring (D415), and 1 missing `raise from` (B904).
+
+No ruff-reported undefined names or security-rule violations were found.
 
 ---
 


### PR DESCRIPTION
Provides load/validate/embed workflow for GLiNER datasets.
CLI: python -m ptbr --file-or-repo <path-or-repo> --validate --generate-label-embeddings <model>
Module: from ptbr import prepare; result = prepare("data.json")

Compatible with all model variants (span, token, bi-encoder, decoder, relex, multitask).

https://claude.ai/code/session_01LVh5Xf67sRwVkTPNbpxAdH