### PR TITLE
Add ptbr data preparation module with typer CLI

### DIFF
--- a/examples/config_ner_basic.yaml
+++ b/examples/config_ner_basic.yaml
@@ -1,0 +1,64 @@
+# =============================================================================
+# Example 1: Basic NER Training (English, span mode)
+# =============================================================================
+# A minimal configuration for training a GLiNER span-based NER model
+# on English text using DeBERTa-v3-small as the backbone.
+#
+# Usage:
+#   python -m ptbr config --file examples/config_ner_basic.yaml --validate
+#   python -m ptbr train main examples/config_ner_basic.yaml
+# =============================================================================
+
+run:
+  name: "gliner-ner-basic"
+  description: "Basic English NER fine-tuning with DeBERTa-v3-small"
+  tags:
+    - "ner"
+    - "english"
+    - "span"
+  seed: 42
+
+model:
+  model_name: "microsoft/deberta-v3-small"
+  name: "gliner-ner-basic"
+  span_mode: "markerV0"
+  max_width: 12
+  hidden_size: 768
+  dropout: 0.3
+  fine_tune: true
+  subtoken_pooling: "first"
+  max_len: 384
+  max_types: 25
+  max_neg_type_ratio: 1
+
+data:
+  root_dir: "logs/ner_basic"
+  train_data: "data/train.json"
+  val_data_dir: "none"
+
+training:
+  num_steps: 10000
+  train_batch_size: 8
+  eval_every: 500
+  warmup_ratio: 0.1
+  scheduler_type: "cosine"
+  lr_encoder: 1.0e-5
+  lr_others: 3.0e-5
+  weight_decay_encoder: 0.01
+  weight_decay_other: 0.01
+  max_grad_norm: 10.0
+  optimizer: "adamw_torch"
+  loss_alpha: -1
+  loss_gamma: 0
+  label_smoothing: 0
+  loss_reduction: "sum"
+  bf16: false
+  save_total_limit: 3
+  dataloader_num_workers: 2
+
+lora:
+  enabled: false
+
+environment:
+  push_to_hub: false
+  report_to: "none"

--- a/examples/config_ner_lora.yaml
+++ b/examples/config_ner_lora.yaml
@@ -1,0 +1,76 @@
+# =============================================================================
+# Example 2: LoRA Fine-Tuning (Memory-Efficient)
+# =============================================================================
+# Fine-tune a GLiNER model using LoRA adapters for reduced VRAM usage.
+# Ideal for consumer GPUs (8-16 GB) or when you want to keep adapter weights
+# small and portable.
+#
+# Usage:
+#   python -m ptbr config --file examples/config_ner_lora.yaml --full-or-lora lora --validate
+#   python -m ptbr train main examples/config_ner_lora.yaml
+# =============================================================================
+
+run:
+  name: "gliner-ner-lora-finetune"
+  description: "LoRA fine-tuning for domain-specific NER"
+  tags:
+    - "ner"
+    - "lora"
+    - "efficient"
+  seed: 123
+
+model:
+  model_name: "microsoft/deberta-v3-base"
+  name: "gliner-ner-lora"
+  span_mode: "markerV0"
+  max_width: 12
+  hidden_size: 768
+  dropout: 0.4
+  fine_tune: true
+  subtoken_pooling: "first"
+  max_len: 512
+  max_types: 25
+  max_neg_type_ratio: 1
+
+data:
+  root_dir: "logs/ner_lora"
+  train_data: "data/train.json"
+  val_data_dir: "data/val.json"
+
+training:
+  num_steps: 5000
+  train_batch_size: 4
+  eval_every: 250
+  warmup_ratio: 0.05
+  scheduler_type: "linear"
+  lr_encoder: 5.0e-5
+  lr_others: 1.0e-4
+  weight_decay_encoder: 0.01
+  weight_decay_other: 0.01
+  max_grad_norm: 1.0
+  optimizer: "adamw_torch"
+  loss_alpha: 0.75
+  loss_gamma: 2.0
+  label_smoothing: 0.1
+  loss_reduction: "sum"
+  bf16: true
+  save_total_limit: 2
+  gradient_accumulation_steps: 4
+  dataloader_num_workers: 4
+  dataloader_pin_memory: true
+
+lora:
+  enabled: true
+  r: 16
+  lora_alpha: 32
+  lora_dropout: 0.05
+  bias: "none"
+  target_modules:
+    - "q_proj"
+    - "v_proj"
+  task_type: "TOKEN_CLS"
+
+environment:
+  push_to_hub: false
+  report_to: "wandb"
+  wandb_project: "gliner-lora-experiments"

--- a/examples/config_token_level.yaml
+++ b/examples/config_token_level.yaml
@@ -1,0 +1,70 @@
+# =============================================================================
+# Example 3: Token-Level NER (Sequence Labeling)
+# =============================================================================
+# Train a token-level GLiNER model (BIO sequence labeling) instead of span-based.
+# Useful for benchmarks that expect token-level predictions (e.g. CoNLL format).
+#
+# Usage:
+#   python -m ptbr config --file examples/config_token_level.yaml --validate
+#   python -m ptbr train main examples/config_token_level.yaml
+# =============================================================================
+
+run:
+  name: "gliner-token-level-ner"
+  description: "Token-level NER using sequence labeling"
+  tags:
+    - "ner"
+    - "token-level"
+    - "conll"
+  seed: 7
+
+model:
+  model_name: "microsoft/deberta-v3-small"
+  name: "gliner-token-ner"
+  span_mode: "token_level"
+  max_width: 12
+  hidden_size: 512
+  dropout: 0.3
+  fine_tune: true
+  subtoken_pooling: "first"
+  max_len: 256
+  max_types: 50
+  max_neg_type_ratio: 1
+  num_rnn_layers: 1
+
+data:
+  root_dir: "logs/token_ner"
+  train_data: "data/train.json"
+  val_data_dir: "data/val.json"
+
+training:
+  num_steps: 20000
+  train_batch_size: 16
+  eval_every: 1000
+  warmup_ratio: 0.1
+  scheduler_type: "cosine"
+  lr_encoder: 2.0e-5
+  lr_others: 5.0e-5
+  weight_decay_encoder: 0.01
+  weight_decay_other: 0.01
+  max_grad_norm: 5.0
+  optimizer: "adamw_torch"
+  loss_alpha: -1
+  loss_gamma: 0
+  label_smoothing: 0
+  loss_reduction: "mean"
+  bf16: false
+  fp16: true
+  save_total_limit: 5
+  dataloader_num_workers: 2
+  dataloader_pin_memory: true
+  dataloader_persistent_workers: true
+  dataloader_prefetch_factor: 4
+
+lora:
+  enabled: false
+
+environment:
+  push_to_hub: true
+  hub_model_id: "my-org/gliner-token-ner-v1"
+  report_to: "none"


### PR DESCRIPTION
Provides load/validate/embed workflow for GLiNER datasets.
CLI: python -m ptbr --file-or-repo <path-or-repo> --validate --generate-label-embeddings <model>
Module: from ptbr import prepare; result = prepare("data.json")

Compatible with all model variants (span, token, bi-encoder, decoder, relex, multitask).

https://claude.ai/code/session_01LVh5Xf67sRwVkTPNbpxAdH