### PR TITLE
Fix 11 failing tests and add skip markers for missing dependencies

### DIFF
--- a/research/training_parameters_report.md
+++ b/research/training_parameters_report.md
@@ -355,43 +355,41 @@ This test file correctly validates the current implementation:
 
 **Verdict**: These tests are well-written and accurately validate the fixes. They use runtime mocking (fake GLiNER + fake torch) to call the real `_launch_training` function and capture all kwargs. This is the authoritative test suite for parameter forwarding.
 
-#### `tests/test_validator_integration.py` -- 47 tests, 25 FAIL
+#### `tests/test_validator_integration.py` -- 47 tests, UPDATED
 
-This file was written to **document bugs**, not verify fixes. Many tests assert that bugs exist (e.g., "this parameter should NOT be forwarded"). Since several bugs have been fixed, these tests now fail -- which is actually the correct outcome.
+This file was originally written to **document bugs**. The 10 tests that asserted old bug behavior have been **updated to verify the fixes** instead:
 
-**Tests that fail because the bug was FIXED** (need to be updated to verify the fix instead):
-
-| Test | Original assertion | Why it fails now |
+| Test (updated) | New assertion | Fix it verifies |
 |---|---|---|
-| `test_dataloader_pin_memory_not_forwarded` (line 305) | Asserts `dataloader_pin_memory` is NOT in `train_model()` call | It IS now forwarded (line 1135) |
-| `test_dataloader_persistent_workers_not_forwarded` (line 317) | Same pattern | Fixed at line 1136 |
-| `test_dataloader_prefetch_factor_not_forwarded` (line 326) | Same pattern | Fixed at line 1137 |
-| `test_run_name_not_forwarded` (line 362) | Asserts `run_name` NOT forwarded | Fixed at line 1140 |
-| `test_output_dir_hardcoded` (line 431) | Asserts `output_dir` is `ast.Constant("models")` | Now uses `str(output_dir)` variable |
-| `test_bf16_hardcoded_to_true` (line 442) | Asserts `bf16` is `ast.Constant(True)` | Now reads from config via `getattr` |
-| `test_eval_batch_size_reuses_train_batch_size` (line 452) | Asserts eval uses `train_batch_size` | Now has separate `eval_batch_size` |
-| `test_label_smoothing_not_forwarded_by_train_py` (line 465) | Asserts `label_smoothing` NOT forwarded | Now forwarded |
-| `test_all_training_fields_in_config_yaml_are_forwarded` (line 508) | Expected `label_smoothing` in missing set | `label_smoothing` is now forwarded |
-| `test_validated_training_fields_not_all_forwarded` (line 740) | Expected 6 gaps including dataloader params | Only 3 dead fields remain as gaps |
+| `test_dataloader_pin_memory_forwarded` | Asserts `dataloader_pin_memory` IS in `train_model()` call | training_cli.py line 1135 |
+| `test_dataloader_persistent_workers_forwarded` | Asserts `dataloader_persistent_workers` IS forwarded | training_cli.py line 1136 |
+| `test_dataloader_prefetch_factor_forwarded` | Asserts `dataloader_prefetch_factor` IS forwarded | training_cli.py line 1137 |
+| `test_run_name_forwarded` | Asserts `run_name` IS forwarded | training_cli.py line 1140 |
+| `test_output_dir_from_config` | Asserts `output_dir` is NOT hardcoded `"models"` | train.py uses `str(output_dir)` |
+| `test_bf16_from_config` | Asserts `bf16` is NOT hardcoded `True` | train.py uses `getattr(cfg.training, "bf16", False)` |
+| `test_eval_batch_size_uses_separate_variable` | Asserts eval uses `eval_batch_size` variable | train.py has separate eval_batch_size |
+| `test_label_smoothing_forwarded_by_train_py` | Asserts `label_smoothing` IS forwarded | train.py line 93 |
+| `test_all_training_fields_in_config_yaml_are_forwarded` | Expected missing set excludes `label_smoothing` | train.py now forwards it |
+| `test_validated_training_fields_not_all_forwarded` | Expected gaps are exactly 3 dead fields | Dataloader params now forwarded |
 
-**Tests that fail due to missing `torch` dependency** (cannot be evaluated in this environment):
+Additionally, `test_training_cli_not_imported_at_module_level` was updated to verify that `training_cli` is lazy-loaded (no longer imported at module level in `__main__.py`).
 
-| Test | Import that fails |
-|---|---|
-| `test_default_remove_unused_columns_is_true` | `gliner.training.trainer.TrainingArguments` requires `torch` |
-| `test_create_training_args_does_not_override_remove_unused_columns` | `gliner.model.BaseGLiNER` requires `torch` |
-| `test_label_smoothing_not_named_parameter` | Same |
-| `test_gradient_checkpointing_not_available` | Same |
-| `test_run_name_not_in_create_training_args` | Same |
-| `test_wrong_structure_loads_without_error` | `gliner.utils.load_config_as_namespace` requires `torch` |
-| `test_missing_required_fields_not_caught` | Same |
-| `test_empty_yaml_crashes_loader` | Same |
-| `test_template_fails_config_cli` | `ptbr.config_cli` imports `gliner.config` which requires `torch` |
-| `test_validate_then_train_is_impossible_with_single_yaml` | Same |
-| Several config_cli-related tests | `config_cli.py` imports `gliner.config.GLiNERConfig` |
+**Tests that are properly SKIPPED** when heavy dependencies are unavailable:
 
-**Tests that fail due to code structure changes:**
-- `test_training_cli_imported_at_module_level` (line 876): Asserts `training_cli` is a top-level import in `__main__.py`. The import structure has changed (training_cli is no longer imported at module level), so this assertion about the bug no longer holds.
+Tests requiring `torch` or `transformers` now use `pytest.importorskip()` and are cleanly skipped in environments without these packages:
+- `test_default_remove_unused_columns_is_true` (`torch`)
+- `test_create_training_args_does_not_override_remove_unused_columns` (`torch`)
+- `test_label_smoothing_not_named_parameter` (`torch`)
+- `test_gradient_checkpointing_not_available` (`torch`)
+- `test_run_name_not_in_create_training_args` (`torch`)
+- `test_template_yaml_fails_config_cli_validation` (`transformers`)
+- `test_no_single_yaml_satisfies_both_clis` (`transformers`)
+- `test_config_cli_expects_lora_config_key` (`transformers`)
+- `test_lora_field_sets_differ_between_clis` (`transformers`)
+- `test_template_fails_config_cli` (`transformers`)
+- `test_validate_then_train_is_impossible_with_single_yaml` (`transformers`)
+
+Note: `test_wrong_structure_loads_without_error`, `test_missing_required_fields_not_caught`, and `test_empty_yaml_crashes_loader` use `gliner.utils` which does NOT require `torch` and run successfully.
 
 **Tests that PASS correctly** (bugs still exist or structural facts still hold):
 
@@ -446,13 +444,11 @@ These tests verify the GLiNER custom Trainer's dataloader methods:
 **HIGH:**
 3. Add `gradient_checkpointing` to schema and forwarding.
 4. Remove or document dead fields (`size_sup`, `shuffle_types`, `random_drop`) from schema and shipped configs.
+5. Update `test_validator_integration.py` tests that assert fixed bugs -- flip assertions to verify fixes work correctly.
 
 **MEDIUM:**
-5. Add `init_lora_weights`, `use_rslora`, `fan_in_fan_out` to LoRA schema and `_apply_lora`.
-6. Add `FEATURE_EXTRACTION` to `task_map` in `_apply_lora`.
-7. Forward Hub-related fields (`push_to_hub`, `hub_model_id`) to TrainingArguments.
-8. Wire `--resume` to `resume_from_checkpoint`.
-9. Make `label_smoothing` an explicit parameter in `create_training_args`.
-
-**TEST MAINTENANCE:**
-10. Update `test_validator_integration.py` tests that document fixed bugs -- flip assertions from "NOT forwarded" to "IS forwarded" for: `dataloader_pin_memory`, `dataloader_persistent_workers`, `dataloader_prefetch_factor`, `run_name`. Update `train.py` AST tests for: `output_dir`, `bf16`, `eval_batch_size`, `label_smoothing`. Update expected gap sets in `test_all_training_fields_in_config_yaml_are_forwarded` and `test_validated_training_fields_not_all_forwarded`.
+6. Add `init_lora_weights`, `use_rslora`, `fan_in_fan_out` to LoRA schema and `_apply_lora`.
+7. Add `FEATURE_EXTRACTION` to `task_map` in `_apply_lora`.
+8. Forward Hub-related fields (`push_to_hub`, `hub_model_id`) to TrainingArguments.
+9. Wire `--resume` to `resume_from_checkpoint`.
+10. Make `label_smoothing` an explicit parameter in `create_training_args`.

--- a/tests/test_validator_integration.py
+++ b/tests/test_validator_integration.py
@@ -2,14 +2,16 @@
 
 These tests catch the critical YAML schema incompatibility between the two
 CLIs and verify that validated config fields actually reach the deep-learning
-training process.  They expose (but do NOT fix) the issues identified in the
-architecture report:
+training process.  They verify both remaining issues and completed fixes:
 
 1. config_cli.py expects ``gliner_config:`` / ``lora_config:`` top-level keys
    while training_cli.py (and template.yaml) expect ``model:`` / ``lora:``.
-2. Parameters validated by training_cli but never forwarded to train_model().
-3. train.py hardcodes output_dir, bf16, and reuses train batch size for eval.
-4. remove_unused_columns defaults to True -- wrong for custom collators.
+2. Parameters validated by training_cli are now forwarded to train_model()
+   (dataloader params, run_name -- verified as fixed).
+3. train.py now reads output_dir from config, bf16 from config, and uses
+   a separate eval_batch_size (verified as fixed).
+4. remove_unused_columns defaults to True -- wrong for custom collators
+   (still open, mitigated by custom Trainer).
 5. LoRA section naming divergence between config_cli and training_cli.
 6. CLI argument style inconsistency (--file vs positional).
 """
@@ -87,6 +89,7 @@ class TestYAMLSchemaIncompatibility:
         Reproduces: ``python -m ptbr config --file ptbr/template.yaml --validate``
         failing with 'Missing gliner_config section'.
         """
+        pytest.importorskip("transformers", reason="config_cli requires transformers")
         from ptbr.config_cli import load_and_validate_config
 
         result = load_and_validate_config(
@@ -133,6 +136,7 @@ class TestYAMLSchemaIncompatibility:
         Adding both doesn't help -- config_cli ignores ``model:`` and
         training_cli ignores ``gliner_config:``.
         """
+        pytest.importorskip("transformers", reason="config_cli requires transformers")
         from ptbr.config_cli import load_and_validate_config
         from ptbr.training_cli import validate_config
 
@@ -186,6 +190,7 @@ class TestLoRASectionNaming:
 
     def test_config_cli_expects_lora_config_key(self):
         """config_cli looks for ``lora_config:``, not ``lora:``."""
+        pytest.importorskip("transformers", reason="config_cli requires transformers")
         from ptbr.config_cli import load_and_validate_config
 
         # Build a valid gliner_config YAML *with* a ``lora:`` section (training_cli style)
@@ -227,6 +232,7 @@ class TestLoRASectionNaming:
 
     def test_lora_field_sets_differ_between_clis(self):
         """config_cli has LoRA fields that training_cli lacks and vice-versa."""
+        pytest.importorskip("transformers", reason="config_cli requires transformers")
         from ptbr.config_cli import _LORA_RULES
         from ptbr.training_cli import _FIELD_SCHEMA
 
@@ -302,34 +308,32 @@ class TestParameterForwardingGaps:
         source = (ROOT / "ptbr" / "training_cli.py").read_text()
         return source
 
-    def test_dataloader_pin_memory_not_forwarded(self):
-        """training.dataloader_pin_memory is validated but never sent to train_model."""
+    def test_dataloader_pin_memory_forwarded(self):
+        """training.dataloader_pin_memory is validated and forwarded to train_model."""
         source = self._get_launch_training_source()
         tree = ast.parse(source)
 
-        # Find the _launch_training function and its model.train_model() call
         forwarded = self._extract_train_model_kwargs(tree)
-        assert "dataloader_pin_memory" not in forwarded, (
-            "dataloader_pin_memory should NOT be in the train_model() call "
-            "(this test documents the bug)"
+        assert "dataloader_pin_memory" in forwarded, (
+            "dataloader_pin_memory should be in the train_model() call (fix verified)"
         )
 
-    def test_dataloader_persistent_workers_not_forwarded(self):
-        """training.dataloader_persistent_workers validated but not forwarded."""
+    def test_dataloader_persistent_workers_forwarded(self):
+        """training.dataloader_persistent_workers is validated and forwarded."""
         source = self._get_launch_training_source()
         tree = ast.parse(source)
         forwarded = self._extract_train_model_kwargs(tree)
-        assert "dataloader_persistent_workers" not in forwarded, (
-            "dataloader_persistent_workers should NOT be in the train_model() call"
+        assert "dataloader_persistent_workers" in forwarded, (
+            "dataloader_persistent_workers should be in the train_model() call (fix verified)"
         )
 
-    def test_dataloader_prefetch_factor_not_forwarded(self):
-        """training.dataloader_prefetch_factor validated but not forwarded."""
+    def test_dataloader_prefetch_factor_forwarded(self):
+        """training.dataloader_prefetch_factor is validated and forwarded."""
         source = self._get_launch_training_source()
         tree = ast.parse(source)
         forwarded = self._extract_train_model_kwargs(tree)
-        assert "dataloader_prefetch_factor" not in forwarded, (
-            "dataloader_prefetch_factor should NOT be in the train_model() call"
+        assert "dataloader_prefetch_factor" in forwarded, (
+            "dataloader_prefetch_factor should be in the train_model() call (fix verified)"
         )
 
     def test_size_sup_not_forwarded(self):
@@ -359,13 +363,13 @@ class TestParameterForwardingGaps:
             "random_drop should NOT be in the train_model() call"
         )
 
-    def test_run_name_not_forwarded(self):
-        """run.name is validated but never forwarded as ``run_name`` to TrainingArguments."""
+    def test_run_name_forwarded(self):
+        """run.name is validated and forwarded as ``run_name`` to TrainingArguments."""
         source = self._get_launch_training_source()
         tree = ast.parse(source)
         forwarded = self._extract_train_model_kwargs(tree)
-        assert "run_name" not in forwarded, (
-            "run_name should NOT be in the train_model() call (W&B runs unnamed)"
+        assert "run_name" in forwarded, (
+            "run_name should be in the train_model() call (fix verified)"
         )
 
     def test_run_tags_not_forwarded(self):
@@ -428,46 +432,49 @@ class TestTrainPyHardcodedValues:
                     return {kw.arg: kw.value for kw in node.keywords if kw.arg}
         return {}
 
-    def test_output_dir_hardcoded(self):
-        """train.py passes output_dir='models' ignoring cfg.data.root_dir."""
+    def test_output_dir_from_config(self):
+        """train.py reads output_dir from cfg.data.root_dir, not hardcoded."""
         tree = self._parse_train_py()
         kwargs = self._extract_train_model_kwargs(tree)
         assert "output_dir" in kwargs, "train.py should pass output_dir"
         node = kwargs["output_dir"]
-        # It should be a constant string "models" -- hardcoded, not from config
-        assert isinstance(node, ast.Constant) and node.value == "models", (
-            "output_dir is hardcoded to 'models' rather than using cfg.data.root_dir"
+        # It should NOT be a hardcoded constant string "models"
+        is_hardcoded = isinstance(node, ast.Constant) and node.value == "models"
+        assert not is_hardcoded, (
+            "output_dir should no longer be hardcoded to 'models' (fix verified)"
         )
 
-    def test_bf16_hardcoded_to_true(self):
-        """train.py hardcodes bf16=True, ignoring any config setting."""
+    def test_bf16_from_config(self):
+        """train.py reads bf16 from config, not hardcoded to True."""
         tree = self._parse_train_py()
         kwargs = self._extract_train_model_kwargs(tree)
         assert "bf16" in kwargs, "train.py should pass bf16"
         node = kwargs["bf16"]
-        assert isinstance(node, ast.Constant) and node.value is True, (
-            "bf16 is hardcoded to True rather than reading from config"
+        # It should NOT be a hardcoded constant True
+        is_hardcoded = isinstance(node, ast.Constant) and node.value is True
+        assert not is_hardcoded, (
+            "bf16 should no longer be hardcoded to True (fix verified)"
         )
 
-    def test_eval_batch_size_reuses_train_batch_size(self):
-        """train.py uses cfg.training.train_batch_size for eval batch size too."""
+    def test_eval_batch_size_uses_separate_variable(self):
+        """train.py uses a separate eval_batch_size, not just train_batch_size."""
         tree = self._parse_train_py()
         kwargs = self._extract_train_model_kwargs(tree)
         assert "per_device_eval_batch_size" in kwargs
 
         node = kwargs["per_device_eval_batch_size"]
-        # It accesses cfg.training.train_batch_size, not a separate eval field
+        # It should use the eval_batch_size variable, not cfg.training.train_batch_size directly
         source_line = ast.dump(node)
-        assert "train_batch_size" in source_line, (
-            "eval batch size should be taken from train_batch_size (documenting the bug)"
+        assert "eval_batch_size" in source_line, (
+            "eval batch size should use the eval_batch_size variable (fix verified)"
         )
 
-    def test_label_smoothing_not_forwarded_by_train_py(self):
-        """train.py does not forward label_smoothing despite it being in configs."""
+    def test_label_smoothing_forwarded_by_train_py(self):
+        """train.py forwards label_smoothing to train_model."""
         tree = self._parse_train_py()
         kwargs = self._extract_train_model_kwargs(tree)
-        assert "label_smoothing" not in kwargs, (
-            "train.py does NOT forward label_smoothing (this is the bug)"
+        assert "label_smoothing" in kwargs, (
+            "train.py should forward label_smoothing (fix verified)"
         )
 
     def test_size_sup_not_forwarded_by_train_py(self):
@@ -547,12 +554,16 @@ class TestConfigFieldsReachTraining:
             if kwarg_name not in forwarded:
                 not_forwarded.append(field)
 
-        # These fields are IN the config but NOT forwarded -- this is the bug
-        expected_missing = {"size_sup", "shuffle_types", "random_drop", "label_smoothing"}
+        # These dead fields are IN the config but NOT forwarded (label_smoothing is now forwarded)
+        expected_missing = {"size_sup", "shuffle_types", "random_drop"}
         actual_missing = set(not_forwarded)
         assert expected_missing.issubset(actual_missing), (
             f"Expected these config fields to be missing from train.py forwarding: "
             f"{expected_missing}. Actually missing: {actual_missing}"
+        )
+        # Verify label_smoothing is no longer in the missing set
+        assert "label_smoothing" not in actual_missing, (
+            "label_smoothing should now be forwarded by train.py (fix verified)"
         )
 
 
@@ -567,6 +578,7 @@ class TestRemoveUnusedColumns:
 
     def test_default_remove_unused_columns_is_true(self):
         """The HF default for remove_unused_columns is True."""
+        pytest.importorskip("torch", reason="requires torch")
         from gliner.training.trainer import TrainingArguments
 
         args = TrainingArguments(output_dir="/tmp/_test_ruc")
@@ -576,6 +588,7 @@ class TestRemoveUnusedColumns:
 
     def test_create_training_args_does_not_override_remove_unused_columns(self):
         """create_training_args does not set remove_unused_columns=False."""
+        pytest.importorskip("torch", reason="requires torch")
         from gliner.model import BaseGLiNER
 
         sig = inspect.signature(BaseGLiNER.create_training_args)
@@ -626,6 +639,7 @@ class TestCreateTrainingArgsGaps:
     def test_label_smoothing_not_named_parameter(self):
         """label_smoothing is a custom TrainingArguments field but not a named
         parameter of create_training_args -- goes through **kwargs."""
+        pytest.importorskip("torch", reason="requires torch")
         from gliner.model import BaseGLiNER
 
         sig = inspect.signature(BaseGLiNER.create_training_args)
@@ -643,6 +657,7 @@ class TestCreateTrainingArgsGaps:
     def test_gradient_checkpointing_not_available(self):
         """gradient_checkpointing is important for large models but absent
         from both create_training_args and the training_cli schema."""
+        pytest.importorskip("torch", reason="requires torch")
         from gliner.model import BaseGLiNER
 
         sig = inspect.signature(BaseGLiNER.create_training_args)
@@ -650,6 +665,7 @@ class TestCreateTrainingArgsGaps:
 
     def test_run_name_not_in_create_training_args(self):
         """run_name is not a parameter of create_training_args."""
+        pytest.importorskip("torch", reason="requires torch")
         from gliner.model import BaseGLiNER
 
         sig = inspect.signature(BaseGLiNER.create_training_args)
@@ -791,17 +807,14 @@ class TestSchemaVsForwarding:
             if kwarg not in forwarded:
                 not_forwarded.append(field)
 
-        # These are the documented gaps
+        # Only the 3 dead fields remain as gaps (dataloader params are now forwarded)
         expected_gaps = {
-            "dataloader_pin_memory",
-            "dataloader_persistent_workers",
-            "dataloader_prefetch_factor",
             "size_sup",
             "shuffle_types",
             "random_drop",
         }
         actual_gaps = set(not_forwarded)
-        assert expected_gaps.issubset(actual_gaps), (
+        assert expected_gaps == actual_gaps, (
             f"Expected forwarding gaps: {expected_gaps}. "
             f"Actual gaps: {actual_gaps}"
         )
@@ -870,11 +883,11 @@ class TestConfigConsistency:
 
 
 class TestMainImportSideEffects:
-    """__main__.py imports training_cli at module level, causing Rich logging
-    handler setup even when only using config or data subcommands."""
+    """__main__.py should lazy-import training_cli to avoid Rich logging
+    handler setup when only using config or data subcommands."""
 
-    def test_training_cli_imported_at_module_level(self):
-        """Verify that training_cli is imported at module level (not lazy)."""
+    def test_training_cli_not_imported_at_module_level(self):
+        """Verify that training_cli is NOT imported at module level (lazy loaded)."""
         source = (ROOT / "ptbr" / "__main__.py").read_text()
         tree = ast.parse(source)
 
@@ -885,9 +898,9 @@ class TestMainImportSideEffects:
                 if isinstance(node, ast.ImportFrom) and node.module:
                     top_level_imports.append(node.module)
 
-        assert any("training_cli" in imp for imp in top_level_imports), (
-            "training_cli is imported at module level in __main__.py "
-            "(causes side effects when using config/data subcommands)"
+        assert not any("training_cli" in imp for imp in top_level_imports), (
+            "training_cli should NOT be imported at module level in __main__.py "
+            "(fix verified: now lazy-loaded via _attach_train_subcommand)"
         )
 
 
@@ -925,6 +938,7 @@ class TestTemplateValidation:
 
     def test_template_fails_config_cli(self):
         """Full template must FAIL config_cli validation (the core bug)."""
+        pytest.importorskip("transformers", reason="config_cli requires transformers")
         from ptbr.config_cli import load_and_validate_config
 
         result = load_and_validate_config(
@@ -949,6 +963,7 @@ class TestEndToEndWorkflow:
         1. Pass config_cli validation (requires gliner_config:)
         2. Pass training_cli validation (requires model:)
         """
+        pytest.importorskip("transformers", reason="config_cli requires transformers")
         from ptbr.config_cli import load_and_validate_config
         from ptbr.training_cli import validate_config
 


### PR DESCRIPTION
Update test_validator_integration.py to verify fixes instead of asserting bugs:
- Flip dataloader_pin_memory/persistent_workers/prefetch_factor tests to assert forwarded
- Flip run_name test to assert forwarded
- Update output_dir, bf16, eval_batch_size, label_smoothing tests for train.py fixes
- Update expected gap sets (now only 3 dead fields remain)
- Fix test_training_cli_not_imported_at_module_level for lazy loading
- Add pytest.importorskip() for 11 tests requiring torch/transformers

Update training_parameters_report.md:
- Elevate test maintenance to HIGH priority (#5)
- Replace failing-test documentation with updated-test verification table

https://claude.ai/code/session_012xJA4irCmbZ8BNk3LRiHBS

## Summary by Sourcery

Update validator integration tests and documentation to reflect recently fixed training parameter forwarding behavior and to skip tests when heavy dependencies are missing.

Bug Fixes:
- Align validator integration tests with current behavior where training parameters and run configuration options are correctly forwarded and training CLI is lazy-loaded rather than imported at module level.

Enhancements:
- Reduce the set of expected missing training fields to the remaining dead fields only, keeping tests as up-to-date verification of real gaps.
- Clarify test and architecture report documentation to emphasize verification of fixes rather than assertion of historical bugs.

Documentation:
- Revise the training parameters report to describe the updated validator integration tests, enumerate which tests now verify fixes, and mark test maintenance as a high priority item.

Tests:
- Flip validator integration tests from asserting known bugs to asserting the corresponding fixes for dataloader settings, run name, output directory, bf16, eval batch size, and label smoothing.
- Adjust expected gap sets in forwarding tests so they only track the three remaining non-forwarded training fields.
- Add pytest.importorskip guards so tests depending on torch or transformers are skipped cleanly when those dependencies are unavailable.