### PR TITLE
fix: update validator integration tests to reflect fixed bugs

### DIFF
--- a/tests/test_validator_integration.py
+++ b/tests/test_validator_integration.py
@@ -306,6 +306,12 @@ class TestParameterForwardingGaps:
 
     @staticmethod
     def _get_launch_training_source() -> str:
+        """
+        Retrieve the source code of ptbr/training_cli.py.
+        
+        Returns:
+            The file contents of ptbr/training_cli.py as a string.
+        """
         source = (ROOT / "ptbr" / "training_cli.py").read_text()
         return source
 
@@ -424,8 +430,15 @@ class TestTrainPyHardcodedValues:
 
     @staticmethod
     def _extract_train_model_kwargs(tree: ast.AST) -> dict[str, Any]:
-        """Extract keyword arguments from the model.train_model() call as
-        {name: ast_node} pairs."""
+        """
+        Locate the keywords passed to a train_model(...) call within an AST and map each keyword name to its corresponding AST value node.
+        
+        Parameters:
+            tree (ast.AST): The AST to search (for example, the Module returned by ast.parse()).
+        
+        Returns:
+            dict[str, ast.AST]: A mapping from keyword argument name to the AST node representing its value; returns an empty dict if no train_model call with keywords is found.
+        """
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
                 func = node.func
@@ -478,7 +491,11 @@ class TestTrainPyHardcodedValues:
         )
 
     def test_size_sup_not_forwarded_by_train_py(self):
-        """train.py does not forward size_sup despite it being in all YAML configs."""
+        """
+        Verify that train.py does not forward the `size_sup` training field to train_model.
+        
+        Asserts that the keyword arguments collected for the call to `train_model` do not include `"size_sup"`.
+        """
         tree = self._parse_train_py()
         kwargs = self._extract_train_model_kwargs(tree)
         assert "size_sup" not in kwargs


### PR DESCRIPTION
Flip assertions for 10 tests that were documenting bugs now fixed:
- dataloader_pin_memory/persistent_workers/prefetch_factor forwarded
- run_name forwarded in training_cli
- output_dir, bf16, eval_batch_size read from config in train.py
- label_smoothing forwarded by train.py
- __main__.py lazy import for training_cli

Add pytest.importorskip guards for tests requiring torch (5) or transformers (6) to gracefully skip in environments without DL deps.

Result: 39 passed, 14 skipped, 0 failures across all 3 test suites.

https://claude.ai/code/session_01AUs6qrS1vZBGhgzDxP1tfV

## Summary by Sourcery

Update validator integration tests to reflect recently fixed configuration forwarding and import behavior while making them robust to missing deep learning dependencies.

Bug Fixes:
- Flip expectations in integration tests that previously documented known bugs so they now assert the corrected forwarding and import behavior.

Tests:
- Guard tests that require transformers or torch with pytest.importorskip so they are skipped when deep learning dependencies are unavailable.
- Update training and config CLI integration tests to verify dataloader_* options, run_name, output_dir, bf16, eval_batch_size, label_smoothing, and lazy training_cli import now behave as intended.
- Adjust gap-detection tests so only truly dead or still-unforwarded config fields are treated as expected omissions.