### PR TITLE
Fix PR review issues: trust_remote_code propagation, validation guard…

### DIFF
--- a/gliner/model.py
+++ b/gliner/model.py
@@ -363,10 +363,11 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         """
         tokenizer_config_path = model_dir / "tokenizer_config.json"
 
+        trust_remote_code = bool(getattr(config, "trust_remote_code", False))
         if tokenizer_config_path.is_file():
-            tokenizer = AutoTokenizer.from_pretrained(model_dir, cache_dir=cache_dir)
+            tokenizer = AutoTokenizer.from_pretrained(model_dir, cache_dir=cache_dir, trust_remote_code=trust_remote_code)
         else:
-            tokenizer = AutoTokenizer.from_pretrained(config.model_name, cache_dir=cache_dir)
+            tokenizer = AutoTokenizer.from_pretrained(config.model_name, cache_dir=cache_dir, trust_remote_code=trust_remote_code)
 
         return cls._set_tokenizer_spec_tokens(tokenizer)
 
@@ -526,7 +527,8 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         # Load tokenizer if requested
         tokenizer = None
         if load_tokenizer:
-            tokenizer = AutoTokenizer.from_pretrained(config_instance.model_name, cache_dir=cache_dir)
+            trust_remote_code = bool(getattr(config_instance, "trust_remote_code", False))
+            tokenizer = AutoTokenizer.from_pretrained(config_instance.model_name, cache_dir=cache_dir, trust_remote_code=trust_remote_code)
             cls._set_tokenizer_spec_tokens(tokenizer)
         # Create model instance from scratch
         instance = cls(
@@ -1216,7 +1218,8 @@ class BaseEncoderGLiNER(BaseGLiNER):
 
     def _create_data_processor(self, config, cache_dir, tokenizer=None, words_splitter=None, **kwargs):
         if tokenizer is None:
-            tokenizer = AutoTokenizer.from_pretrained(config.model_name, cache_dir=cache_dir)
+            trust_remote_code = bool(getattr(config, "trust_remote_code", False))
+            tokenizer = AutoTokenizer.from_pretrained(config.model_name, cache_dir=cache_dir, trust_remote_code=trust_remote_code)
             self._set_tokenizer_spec_tokens(tokenizer)
         self.data_processor = self.data_processor_class(config, tokenizer, words_splitter)
         return self.data_processor
@@ -1673,9 +1676,10 @@ class BaseEncoderGLiNER(BaseGLiNER):
 
 class BaseBiEncoderGLiNER(BaseEncoderGLiNER):
     def _create_data_processor(self, config, cache_dir, tokenizer=None, words_splitter=None, **kwargs):
-        labels_tokenizer = AutoTokenizer.from_pretrained(config.labels_encoder, cache_dir=cache_dir)
+        trust_remote_code = bool(getattr(config, "trust_remote_code", False))
+        labels_tokenizer = AutoTokenizer.from_pretrained(config.labels_encoder, cache_dir=cache_dir, trust_remote_code=trust_remote_code)
         if tokenizer is None:
-            tokenizer = AutoTokenizer.from_pretrained(config.model_name, cache_dir=cache_dir)
+            tokenizer = AutoTokenizer.from_pretrained(config.model_name, cache_dir=cache_dir, trust_remote_code=trust_remote_code)
             self._set_tokenizer_spec_tokens(tokenizer)
 
         self.data_processor = self.data_processor_class(
@@ -2146,8 +2150,9 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
 
     def _create_data_processor(self, config, cache_dir, tokenizer=None, words_splitter=None, **kwargs):
         """Create data processor with decoder tokenizer."""
+        trust_remote_code = bool(getattr(config, "trust_remote_code", False))
         if tokenizer is None:
-            tokenizer = AutoTokenizer.from_pretrained(config.model_name, cache_dir=cache_dir)
+            tokenizer = AutoTokenizer.from_pretrained(config.model_name, cache_dir=cache_dir, trust_remote_code=trust_remote_code)
             self._set_tokenizer_spec_tokens(tokenizer)
 
         if words_splitter is None:
@@ -2157,7 +2162,7 @@ class UniEncoderSpanDecoderGLiNER(BaseEncoderGLiNER):
         decoder_tokenizer = None
         if config.labels_decoder is not None:
             decoder_tokenizer = AutoTokenizer.from_pretrained(
-                config.labels_decoder, cache_dir=cache_dir, add_prefix_space=True
+                config.labels_decoder, cache_dir=cache_dir, add_prefix_space=True, trust_remote_code=trust_remote_code
             )
             if decoder_tokenizer.pad_token is None:
                 decoder_tokenizer.pad_token = decoder_tokenizer.eos_token
@@ -2438,7 +2443,8 @@ class UniEncoderSpanRelexGLiNER(BaseEncoderGLiNER):
     def _create_data_processor(self, config, cache_dir, tokenizer=None, words_splitter=None, **kwargs):
         """Create relation extraction data processor."""
         if tokenizer is None:
-            tokenizer = AutoTokenizer.from_pretrained(config.model_name, cache_dir=cache_dir)
+            trust_remote_code = bool(getattr(config, "trust_remote_code", False))
+            tokenizer = AutoTokenizer.from_pretrained(config.model_name, cache_dir=cache_dir, trust_remote_code=trust_remote_code)
             self._set_tokenizer_spec_tokens(tokenizer)
 
         if words_splitter is None:

--- a/ptbr/__main__.py
+++ b/ptbr/__main__.py
@@ -84,9 +84,13 @@ def data_cmd(
         from gliner import GLiNER
 
         typer.echo(f"Loading model: {generate_label_embeddings}")
-        model = GLiNER.from_pretrained(
-            generate_label_embeddings, trust_remote_code=trust_remote_code
-        )
+        try:
+            model = GLiNER.from_pretrained(
+                generate_label_embeddings, trust_remote_code=trust_remote_code
+            )
+        except Exception as exc:
+            typer.echo(f"Failed to load model '{generate_label_embeddings}': {exc}", err=True)
+            raise typer.Exit(code=1) from exc
 
         typer.echo(f"Encoding {len(labels)} labels...")
         embeddings = model.encode_labels(labels)

--- a/ptbr/data.py
+++ b/ptbr/data.py
@@ -245,7 +245,7 @@ def prepare(
         result.is_valid = is_valid
         result.validation_errors = errs
 
-    if generate_label_embeddings:
+    if generate_label_embeddings and (not validate or is_valid):
         from gliner import GLiNER
 
         model = GLiNER.from_pretrained(

--- a/ptbr/tests/test_training_cli.py
+++ b/ptbr/tests/test_training_cli.py
@@ -536,7 +536,7 @@ class TestCLI:
         assert result.exit_code == 0
         mock_launch.assert_called_once()
 
-    def test_validate_writes_summary(self, cfg_file: Path, tmp_path: Path) -> None:
+    def test_validate_writes_summary(self, cfg_file: Path) -> None:
         result = runner.invoke(app, [str(cfg_file), "--validate"])
         assert result.exit_code == 0
         summaries = list(cfg_file.parent.glob("summary_*.txt"))


### PR DESCRIPTION
…s, error handling

- Propagate trust_remote_code to all AutoTokenizer.from_pretrained calls in gliner/model.py (_load_tokenizer, load_from_config, and all _create_data_processor variants)
- Skip label-embedding generation when data validation fails in ptbr/data.py prepare()
- Add error handling with friendly message for model loading failures in ptbr/__main__.py data command
- Remove unused tmp_path parameter from test_validate_writes_summary

https://claude.ai/code/session_01VjxgpFPTiGdHnCgDDYzrsG

## Summary by Sourcery

Propagate trust_remote_code settings through tokenizer and data processor creation, guard label-embedding generation behind successful validation, improve CLI error handling when model loading fails, and clean up an unused test parameter.

Bug Fixes:
- Ensure trust_remote_code configuration is honored for all AutoTokenizer.from_pretrained calls used by GLiNER models.
- Skip label-embedding generation when dataset validation fails to avoid running on invalid data.
- Provide a clear CLI error message and non-zero exit when model loading fails in the data command.

Enhancements:
- Remove an unused tmp_path parameter from a training CLI validation test to simplify the test signature.