### PR TITLE
Fix all PR #39 review comments from coderabbitai and gemini

### DIFF
--- a/ptbr/__main__.py
+++ b/ptbr/__main__.py
@@ -93,7 +93,15 @@ def data_cmd(
             raise typer.Exit(code=1) from exc
 
         typer.echo(f"Encoding {len(labels)} labels...")
-        embeddings = model.encode_labels(labels)
+        try:
+            embeddings = model.encode_labels(labels)
+        except NotImplementedError:
+            typer.echo(
+                f"Model '{generate_label_embeddings}' does not support label encoding "
+                f"(not a bi-encoder model). Use a bi-encoder model for label embeddings.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
 
         torch.save(embeddings, output_embeddings_path)
         with open(output_labels_path, "w", encoding="utf-8") as f:

--- a/ptbr/config_cli.py
+++ b/ptbr/config_cli.py
@@ -13,6 +13,7 @@ Usage as module:
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 from typing import Any, Dict, List, Tuple, Literal, Optional
@@ -238,7 +239,7 @@ def _validate_section(
                         field_path,
                         f"Not set; using default: {default!r}",
                     )
-                result[key] = default
+                result[key] = copy.deepcopy(default)
                 continue
 
         # --- Type coercion ---

--- a/ptbr/template.yaml
+++ b/ptbr/template.yaml
@@ -363,8 +363,8 @@ training:
 
   # Masking strategy during training.
   # Options: "none", "global"
-  # Default: "none"
-  masking: "none"
+  # Default: "global"
+  masking: "global"
 
   # ---- Checkpointing & logging ----
 

--- a/ptbr/tests/test_training_cli.py
+++ b/ptbr/tests/test_training_cli.py
@@ -869,7 +869,7 @@ class TestLaunchTrainingPropagation:
         cfg = self._make_cfg(tmp_path)
         cfg["lora"]["enabled"] = True
         cfg["lora"]["r"] = 16
-        captured = self._patch_fake_runtime(monkeypatch)
+        self._patch_fake_runtime(monkeypatch)
 
         with mock.patch("ptbr.training_cli._apply_lora") as mock_apply:
             _launch_training(cfg, tmp_path / "artifacts", resume=False, config_dir=tmp_path)

--- a/ptbr/tests/test_validation.py
+++ b/ptbr/tests/test_validation.py
@@ -37,6 +37,7 @@ def report(name, passed, detail=""):
         FAIL += 1
     suffix = f"  ({detail})" if detail else ""
     print(f"  [{status}] {name}{suffix}")
+    assert passed, f"[FAIL] {name}{suffix}"
 
 
 def load_mock(filename):
@@ -341,7 +342,7 @@ def _run_validate_cli(path):
     if importlib.util.find_spec("typer") is None:
         return None
     return subprocess.run(
-        [sys.executable, "-m", "ptbr", "--file-or-repo", str(path), "--validate"],
+        [sys.executable, "-m", "ptbr", "data", "--file-or-repo", str(path), "--validate"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
         check=False,

--- a/ptbr/training_cli.py
+++ b/ptbr/training_cli.py
@@ -1144,7 +1144,7 @@ def _launch_training(
         save_total_limit=train_cfg["save_total_limit"],
         # Evaluation — run eval at the same cadence as checkpointing when
         # an eval dataset is available.
-        **({"eval_strategy": "steps", "eval_steps": train_cfg.get("eval_steps") or train_cfg["eval_every"]}
+        **({"eval_strategy": "steps", "eval_steps": val if (val := train_cfg.get("eval_steps")) is not None else train_cfg["eval_every"]}
            if eval_dataset is not None else {}),
         # Precision
         bf16=train_cfg.get("bf16", False),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,11 +58,9 @@ tokenizers = [
     "camel_tools",
     "indic-nlp-library",
     "spacy",
-    "stanza"
 ]
 training = ["accelerate"]
 stanza = [
-    "stanza",
     "langdetect"
 ]
 
@@ -78,7 +76,7 @@ dev = [
 line-length = 120
 indent-width = 4
 output-format = "grouped"
-target-version = "py39"
+target-version = "py311"
 
 # Exclude common directories
 exclude = [

--- a/ralph.yml
+++ b/ralph.yml
@@ -16,9 +16,6 @@ event_loop:
 cli:
   backend: "claude"
 
-core:
-  specs_dir: "./specs/"
-
 # Define what each custom event means
 events:
   deploy.ready:

--- a/train.py
+++ b/train.py
@@ -102,6 +102,9 @@ def main(cfg_path: str):
         freeze_components=freeze_components,
         # Dtype
         bf16=getattr(cfg.training, "bf16", False),
+        fp16=getattr(cfg.training, "fp16", False),
+        # Gradient checkpointing
+        gradient_checkpointing=getattr(cfg.training, "gradient_checkpointing", False),
     )
 
     print(f"\n✓ Training complete! Model saved to {output_dir}")


### PR DESCRIPTION
- train.py: Forward fp16 and gradient_checkpointing to model.train_model
- ptbr/training_cli.py: Align masking default to "global" (matching upstream), add gradient_checkpointing and eval_steps to _FIELD_SCHEMA, allow eval_steps override instead of hardcoding to eval_every, forward gradient_checkpointing
- ptbr/__main__.py: Catch NotImplementedError for non-biencoder models in encode_labels with user-friendly error message
- ptbr/config_cli.py: Use copy.deepcopy for mutable defaults to prevent cross-call mutation leaks
- ptbr/template.yaml: Align masking default to "global"
- ptbr/tests/test_training_cli.py: Remove unused captured variable
- ptbr/tests/test_validation.py: Add assert to report() so pytest actually fails on test failures; fix CLI test to include "data" subcommand
- pyproject.toml: Align ruff target-version to py311 matching requires-python, deduplicate stanza from optional deps (already in core deps)
- ralph.yml: Remove non-existent ./specs/ directory reference

https://claude.ai/code/session_01AjyXRkmJBPLhCczVHPUNLH

## Summary by Sourcery

Address configuration, CLI, and tooling review comments across training, validation, and project metadata.

New Features:
- Allow configuring gradient checkpointing and fp16 precision through both the training CLI and top-level train script.

Bug Fixes:
- Ensure validation test failures surface as pytest failures by asserting in the report helper.
- Fix the validation CLI test to invoke the correct `data` subcommand.
- Prevent cross-call mutation of default configuration values by deep-copying mutable defaults in the config CLI.
- Provide a clear error and exit when attempting label encoding with unsupported (non-biencoder) models in the data CLI.

Enhancements:
- Align the default masking strategy to "global" in both the training CLI schema and template configuration.
- Allow overriding evaluation steps independently of checkpoint interval via a new `training.eval_steps` option.
- Simplify ralph configuration by removing a reference to a non-existent specs directory.
- Clean up tests by removing unused variables in training CLI tests.

Build:
- Align Ruff's target Python version with the project's declared minimum Python version and deduplicate stanza dependency declarations in pyproject.toml.