### PR TITLE
Fix all PR review comments and 15 test failures

### DIFF
--- a/ptbr/tests/test_training_cli.py
+++ b/ptbr/tests/test_training_cli.py
@@ -624,10 +624,17 @@ class TestApplyLora:
             def __init__(self, **kwargs):
                 self.kwargs = kwargs
 
+        class FakePeftModel:
+            def __init__(self, target):
+                self._target = target
+
+            def parameters(self):
+                return iter([])
+
         def fake_get_peft_model(target, peft_config):
             calls["target"] = target
             calls["peft_config"] = peft_config
-            return ("wrapped", target)
+            return FakePeftModel(target)
 
         fake_peft = types.SimpleNamespace(
             LoraConfig=FakeLoraConfig,
@@ -649,7 +656,8 @@ class TestApplyLora:
 
         assert calls["target"] is backbone
         assert model.model.token_rep_layer is token_rep_layer
-        assert model.model.token_rep_layer.bert_layer.model == ("wrapped", backbone)
+        peft_model = model.model.token_rep_layer.bert_layer.model
+        assert peft_model._target is backbone
 
         peft_config = calls["peft_config"]
         assert peft_config.kwargs["r"] == 8
@@ -755,6 +763,9 @@ class TestLaunchTrainingPropagation:
             def to(self, dtype=None):
                 captured["to_dtype"] = dtype
                 return self
+
+            def parameters(self):
+                return iter([])
 
             def train_model(self, **kwargs):
                 captured["train_kwargs"] = kwargs

--- a/ptbr/training_cli.py
+++ b/ptbr/training_cli.py
@@ -1039,7 +1039,11 @@ _HF_DATASET_REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-
 
 def _looks_like_hf_dataset_repo(value: str) -> bool:
     """Return True when `value` looks like a HF dataset repo id `owner/name`."""
-    return bool(_HF_DATASET_REPO_RE.match(value.strip()))
+    v = value.strip()
+    # Local file extensions should never be treated as HF repos
+    if any(v.endswith(ext) for ext in (".json", ".jsonl", ".csv", ".tsv", ".parquet", ".yaml", ".yml")):
+        return False
+    return bool(_HF_DATASET_REPO_RE.match(v))
 
 
 def _resolve_data_source(path_value: str, config_dir: Path, default_split: str) -> tuple[str, str, bool]:
@@ -1308,7 +1312,8 @@ def _launch_training(
     logger.info("[DIAG]  Model architecture summary")
     logger.info(f"[DIAG]    Class:            {type(model).__name__}")
     logger.info(f"[DIAG]    Total params:     {total_params:,}")
-    logger.info(f"[DIAG]    Trainable params: {trainable_params:,} ({100 * trainable_params / total_params:.2f}%)")
+    pct = (100 * trainable_params / total_params) if total_params else 0.0
+    logger.info(f"[DIAG]    Trainable params: {trainable_params:,} ({pct:.2f}%)")
     logger.info("[DIAG]  Dataset sizes")
     logger.info(f"[DIAG]    Train: {len(train_dataset)}")
     logger.info(f"[DIAG]    Eval:  {len(eval_dataset) if eval_dataset else 'None'}")
@@ -1392,7 +1397,8 @@ def _apply_lora(model: Any, lora_cfg: dict) -> None:
         )
         trainable = sum(p.numel() for p in model.model.token_rep_layer.bert_layer.model.parameters() if p.requires_grad)
         total = sum(p.numel() for p in model.model.token_rep_layer.bert_layer.model.parameters())
-        logger.info(f"[LORA]     Trainable params: {trainable:,} / {total:,} ({100 * trainable / total:.2f}%)")
+        lora_pct = (100 * trainable / total) if total else 0.0
+        logger.info(f"[LORA]     Trainable params: {trainable:,} / {total:,} ({lora_pct:.2f}%)")
     else:
         logger.warning("[LORA]     Could not locate model.model.token_rep_layer.bert_layer.model; LoRA not applied")
 

--- a/scripts/build_canonical_gliner_dataset.py
+++ b/scripts/build_canonical_gliner_dataset.py
@@ -352,7 +352,12 @@ def normalize_gliner2_row(
             used_for_label.add(span)
             spans.append((span[0], span[1], normalized_label))
 
-    return {"tokenized_text": tokens, "ner": dedupe_and_sort_spans(spans)}
+    ner = dedupe_and_sort_spans(spans)
+    if not ner:
+        stats.dropped_no_mapped_entities[source] += 1
+        return None
+
+    return {"tokenized_text": tokens, "ner": ner}
 
 
 def normalize_char_span_row(

--- a/tests/test_validator_integration.py
+++ b/tests/test_validator_integration.py
@@ -256,15 +256,46 @@ class TestParameterForwarding:
 
     @staticmethod
     def _extract_train_model_kwargs(tree: ast.AST) -> set[str]:
-        """Extract keyword argument names from the model.train_model() call."""
-        kwargs = set()
+        """Extract keyword argument names forwarded to model.train_model().
+
+        Handles both direct keyword args (``model.train_model(foo=bar)``) and
+        dict-splat patterns (``model.train_model(**train_kwargs)``) by
+        collecting keys from the dict literal assigned to the splatted variable.
+        """
+        kwargs: set[str] = set()
+        # Collect keys from dict literals assigned to any variable that is
+        # later splatted into train_model(**var).
+        dict_var_keys: dict[str, set[str]] = {}
+        for node in ast.walk(tree):
+            # Detect: var = { "key": ..., ... }  or  var: type = { "key": ..., ... }
+            target = None
+            value = None
+            if isinstance(node, ast.Assign) and len(node.targets) == 1:
+                target = node.targets[0]
+                value = node.value
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                target = node.target
+                value = node.value
+            if isinstance(target, ast.Name) and isinstance(value, ast.Dict):
+                keys: set[str] = set()
+                for k in value.keys:
+                    if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                        keys.add(k.value)
+                dict_var_keys[target.id] = keys
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
                 func = node.func
                 if isinstance(func, ast.Attribute) and func.attr == "train_model":
+                    # Direct keyword args
                     for kw in node.keywords:
                         if kw.arg is not None:
                             kwargs.add(kw.arg)
+                        # **var splat
+                        elif kw.arg is None and isinstance(kw.value, ast.Name):
+                            var_name = kw.value.id
+                            if var_name in dict_var_keys:
+                                kwargs.update(dict_var_keys[var_name])
         return kwargs
 
     def test_dataloader_pin_memory_forwarded(self):
@@ -577,14 +608,7 @@ class TestRemoveUnusedColumns:
         """_launch_training now passes remove_unused_columns to train_model."""
         source = (ROOT / "ptbr" / "training_cli.py").read_text()
         tree = ast.parse(source)
-        forwarded = set()
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call):
-                func = node.func
-                if isinstance(func, ast.Attribute) and func.attr == "train_model":
-                    for kw in node.keywords:
-                        if kw.arg:
-                            forwarded.add(kw.arg)
+        forwarded = TestParameterForwarding._extract_train_model_kwargs(tree)
         assert "remove_unused_columns" in forwarded, (
             "_launch_training should set remove_unused_columns=False"
         )
@@ -735,14 +759,7 @@ class TestSchemaVsForwarding:
 
         source = (ROOT / "ptbr" / "training_cli.py").read_text()
         tree = ast.parse(source)
-        forwarded = set()
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call):
-                func = node.func
-                if isinstance(func, ast.Attribute) and func.attr == "train_model":
-                    for kw in node.keywords:
-                        if kw.arg:
-                            forwarded.add(kw.arg)
+        forwarded = TestParameterForwarding._extract_train_model_kwargs(tree)
 
         schema_to_kwarg = {
             "num_steps": "max_steps",
@@ -762,6 +779,8 @@ class TestSchemaVsForwarding:
 
         handled_elsewhere = {
             "prev_path", "freeze_components", "compile_model",
+            # Conditionally forwarded (only when eval dataset present)
+            "eval_steps", "eval_on_start",
         }
 
         not_forwarded = []


### PR DESCRIPTION
- training_cli.py: Exclude file extensions from HF dataset repo detection so paths like data/missing_train.json aren't treated as HF repos; guard division by zero in diagnostic param logging; guard division by zero in LoRA param logging
- test_training_cli.py: Add parameters() method to FakeModel and FakePeftModel so diagnostic logging doesn't crash; fix LoRA test assertion for new FakePeftModel
- test_validator_integration.py: Update AST-based kwarg extraction to handle dict-splat pattern (model.train_model(**train_kwargs)) and annotated assignments (AnnAssign); add eval_steps/eval_on_start to handled_elsewhere set (conditionally forwarded)
- build_canonical_gliner_dataset.py: Drop rows with empty NER spans in normalize_gliner2_row to avoid injecting false negatives

https://claude.ai/code/session_01AjyXRkmJBPLhCczVHPUNLH

## Summary by Sourcery

Fix training CLI edge cases, update validator and LoRA tests, and harden GLiNER dataset normalization against empty-entity rows.

Bug Fixes:
- Prevent local file paths with known data file extensions from being misclassified as Hugging Face dataset repo IDs in the training CLI.
- Guard diagnostic and LoRA parameter percentage logging against division by zero when total parameter counts are zero.
- Avoid including rows with no mapped NER entities when building the canonical GLiNER dataset.

Enhancements:
- Improve AST-based extraction of forwarded training arguments to handle dict-splat call patterns and annotated assignments, and to centralize this logic in a reusable helper.

Tests:
- Extend training CLI tests with fake models that expose parameters() to support new diagnostic and LoRA logging behavior without failures.
- Update validator integration tests to use the shared AST kwarg extraction helper and to cover dict-splat patterns and conditionally forwarded eval-related arguments.