### PR TITLE
Claude/fix gliner pr comments j0 l pk

### DIFF
--- a/configs/config_tiny_test.yaml
+++ b/configs/config_tiny_test.yaml
@@ -18,7 +18,7 @@ model:
   decoder_mode: "span"
 
 data:
-  root_dir: /tmp/gliner_tiny_1k
+  root_dir: gliner_tiny_1k
   train_data: "../examples/sample_data.json"
   val_data_dir: "../data/tiny_eval.json"
 

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -986,10 +986,14 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
 
     def unfreeze_component(self, component_name: str):
         """
-        Unfreeze a specific component of the model.
-
-        Args:
-            component_name: Name of component to unfreeze
+        Unfreeze a named model component by enabling gradient updates on its parameters.
+        
+        Parameters:
+            component_name (str): Key of the component to unfreeze as returned by `_get_freezable_components()`.
+        
+        Behavior:
+            Sets `requires_grad=True` on all parameters of the named component. If the component is not found,
+            emits a warning listing available component keys.
         """
         components = self._get_freezable_components()
         if component_name in components:
@@ -1000,12 +1004,24 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
             warnings.warn(f"Component '{component_name}' not found. Available components: {available}", stacklevel=2)
 
     def _apply_lora(self, lora_config: dict) -> None:
-        """Apply a LoRA adapter to the model's encoder backbone in-place.
-
+        """
+        Attach a PEFT LoRA adapter to the model's encoder backbone in-place.
+        
         Parameters:
-            lora_config: Dict with keys ``r``, ``lora_alpha``, ``lora_dropout``,
-                ``bias``, ``target_modules``, and optionally ``task_type``
-                (default ``"TOKEN_CLS"``) and ``modules_to_save``.
+            lora_config (dict): Configuration for the LoRA adapter. Expected keys:
+                - "r" (int): LoRA rank.
+                - "lora_alpha" (float|int): LoRA scaling coefficient.
+                - "target_modules" (list[str]): Names of modules to apply LoRA to.
+                - Optional "lora_dropout" (float): Dropout for LoRA (default 0.05).
+                - Optional "bias" (str): Bias mode for LoRA (default "none").
+                - Optional "task_type" (str): One of "TOKEN_CLS", "SEQ_CLS", "CAUSAL_LM",
+                  "SEQ_2_SEQ_LM", "FEATURE_EXTRACTION" (default "TOKEN_CLS").
+                - Optional "modules_to_save" (list[str]): Modules to keep trainable/saved.
+        
+        Raises:
+            ImportError: If the `peft` library is not installed.
+            RuntimeError: If the encoder backbone cannot be located at
+                `self.model.token_rep_layer.bert_layer.model` and LoRA cannot be applied.
         """
         try:
             from peft import TaskType, LoraConfig, get_peft_model
@@ -1207,27 +1223,26 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         **training_kwargs,
     ) -> Trainer:
         """
-        Execute training with Hugging Face's Trainer using the provided datasets and training configuration.
-
-        If `training_args` is None, a TrainingArguments object is created from `output_dir` and `training_kwargs`. When `eval_dataset` is provided and no evaluation strategy is set, evaluation is enabled with `eval_strategy='steps'` and `eval_steps` defaulting to `save_steps`.
-
+        Train the model using Hugging Face's Trainer with the provided training and evaluation datasets.
+        
+        The method will create TrainingArguments from output_dir and additional kwargs if none are provided, optionally apply a PEFT LoRA adapter to the encoder backbone when lora_config is given, enable evaluation automatically when an eval_dataset is supplied but no evaluation strategy is set, optionally compile the model and freeze specified components, and then run training (optionally resuming from a checkpoint).
+        
         Parameters:
-            train_dataset: The dataset used for training.
-            eval_dataset: The dataset used for evaluation (may be None).
-            training_args: Optional TrainingArguments; created from `output_dir` and `training_kwargs` if not provided.
-            freeze_components: Optional list of component names to freeze before training (e.g., ['text_encoder', 'decoder']).
-            compile_model: If True, compiles the model (via self.compile()) before training.
-            output_dir: Directory to save training outputs; required if `training_args` is None.
-            resume_from_checkpoint: Path to a checkpoint to resume from, or True to auto-detect the latest checkpoint; if None training starts from scratch.
-            lora_config: Optional LoRA configuration dict. When provided, a PEFT LoRA adapter
-                is applied to the model's encoder backbone before training. Expected keys:
-                ``r``, ``lora_alpha``, ``lora_dropout``, ``bias``, ``target_modules``.
-                Optional keys: ``task_type`` (default ``"TOKEN_CLS"``), ``modules_to_save``.
-                Requires the ``peft`` package (``pip install peft``).
-            **training_kwargs: Additional keyword arguments forwarded to `create_training_args` when `training_args` is not provided.
-
+            train_dataset: Dataset used for training.
+            eval_dataset: Dataset used for evaluation, or None.
+            training_args (Optional[TrainingArguments]): Pre-built training arguments. If None, TrainingArguments are created from output_dir and training_kwargs.
+            freeze_components (Optional[list[str]]): Names of model components to freeze before training (e.g., ["text_encoder", "decoder"]).
+            compile_model (bool): If True, compile the model prior to training.
+            output_dir (Optional[Union[str, Path]]): Directory to save training outputs; required when training_args is None.
+            resume_from_checkpoint (Optional[Union[str, Path, bool]]): Path to a checkpoint to resume from, or True to auto-detect the latest checkpoint; None starts training from scratch.
+            lora_config (Optional[dict]): PEFT LoRA configuration. When provided, a LoRA adapter is applied to the encoder backbone before training. Expected keys include `r`, `lora_alpha`, `lora_dropout`, `bias`, and `target_modules`. Optional keys: `task_type`, `modules_to_save`. Requires the `peft` package to be installed.
+            **training_kwargs: Additional keyword arguments forwarded to create_training_args when training_args is not provided.
+        
         Returns:
-            The Trainer instance used to run training (with trained model weights).
+            Trainer: The Trainer instance used to run training; the model's weights will be updated by the training run.
+        
+        Raises:
+            ValueError: If both `training_args` and `output_dir` are None.
         """
         # Apply LoRA adapter if requested
         if lora_config is not None:

--- a/gliner/model.py
+++ b/gliner/model.py
@@ -999,6 +999,75 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
             available = ", ".join(components.keys())
             warnings.warn(f"Component '{component_name}' not found. Available components: {available}", stacklevel=2)
 
+    def _apply_lora(self, lora_config: dict) -> None:
+        """Apply a LoRA adapter to the model's encoder backbone in-place.
+
+        Parameters:
+            lora_config: Dict with keys ``r``, ``lora_alpha``, ``lora_dropout``,
+                ``bias``, ``target_modules``, and optionally ``task_type``
+                (default ``"TOKEN_CLS"``) and ``modules_to_save``.
+        """
+        try:
+            from peft import TaskType, LoraConfig, get_peft_model
+        except ImportError:
+            raise ImportError(
+                "peft is required for LoRA training. Install with: pip install peft"
+            )
+
+        task_map = {
+            "TOKEN_CLS": TaskType.TOKEN_CLS,
+            "SEQ_CLS": TaskType.SEQ_CLS,
+            "CAUSAL_LM": TaskType.CAUSAL_LM,
+            "SEQ_2_SEQ_LM": TaskType.SEQ_2_SEQ_LM,
+            "FEATURE_EXTRACTION": TaskType.FEATURE_EXTRACTION,
+        }
+        task_type = task_map.get(
+            lora_config.get("task_type", "TOKEN_CLS"), TaskType.TOKEN_CLS
+        )
+
+        peft_cfg = LoraConfig(
+            r=lora_config["r"],
+            lora_alpha=lora_config["lora_alpha"],
+            lora_dropout=lora_config.get("lora_dropout", 0.05),
+            bias=lora_config.get("bias", "none"),
+            target_modules=lora_config["target_modules"],
+            task_type=task_type,
+            modules_to_save=lora_config.get("modules_to_save"),
+        )
+
+        try:
+            backbone = self.model.token_rep_layer.bert_layer.model
+        except AttributeError:
+            backbone = None
+
+        if backbone is None:
+            raise RuntimeError(
+                "Could not locate the encoder backbone at "
+                "model.token_rep_layer.bert_layer.model; LoRA cannot be applied."
+            )
+
+        self.model.token_rep_layer.bert_layer.model = get_peft_model(
+            backbone, peft_cfg
+        )
+        trainable = sum(
+            p.numel()
+            for p in self.model.token_rep_layer.bert_layer.model.parameters()
+            if p.requires_grad
+        )
+        total = sum(
+            p.numel()
+            for p in self.model.token_rep_layer.bert_layer.model.parameters()
+        )
+        pct = (100 * trainable / total) if total else 0.0
+        logger.info(
+            "LoRA applied (r=%d, alpha=%s). Trainable: %s / %s (%.2f%%)",
+            lora_config["r"],
+            lora_config["lora_alpha"],
+            f"{trainable:,}",
+            f"{total:,}",
+            pct,
+        )
+
     @classmethod
     def create_training_args(
         cls,
@@ -1134,13 +1203,14 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
         compile_model: bool = False,
         output_dir: Optional[Union[str, Path]] = None,
         resume_from_checkpoint: Optional[Union[str, Path, bool]] = None,
+        lora_config: Optional[dict] = None,
         **training_kwargs,
     ) -> Trainer:
         """
         Execute training with Hugging Face's Trainer using the provided datasets and training configuration.
-        
+
         If `training_args` is None, a TrainingArguments object is created from `output_dir` and `training_kwargs`. When `eval_dataset` is provided and no evaluation strategy is set, evaluation is enabled with `eval_strategy='steps'` and `eval_steps` defaulting to `save_steps`.
-        
+
         Parameters:
             train_dataset: The dataset used for training.
             eval_dataset: The dataset used for evaluation (may be None).
@@ -1149,11 +1219,19 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
             compile_model: If True, compiles the model (via self.compile()) before training.
             output_dir: Directory to save training outputs; required if `training_args` is None.
             resume_from_checkpoint: Path to a checkpoint to resume from, or True to auto-detect the latest checkpoint; if None training starts from scratch.
+            lora_config: Optional LoRA configuration dict. When provided, a PEFT LoRA adapter
+                is applied to the model's encoder backbone before training. Expected keys:
+                ``r``, ``lora_alpha``, ``lora_dropout``, ``bias``, ``target_modules``.
+                Optional keys: ``task_type`` (default ``"TOKEN_CLS"``), ``modules_to_save``.
+                Requires the ``peft`` package (``pip install peft``).
             **training_kwargs: Additional keyword arguments forwarded to `create_training_args` when `training_args` is not provided.
-        
+
         Returns:
             The Trainer instance used to run training (with trained model weights).
         """
+        # Apply LoRA adapter if requested
+        if lora_config is not None:
+            self._apply_lora(lora_config)
         # Create training arguments if not provided
         if training_args is None:
             if output_dir is None:

--- a/gliner/training/trainer.py
+++ b/gliner/training/trainer.py
@@ -347,7 +347,8 @@ class Trainer(transformers.Trainer):
 
         if self.args.dataloader_num_workers > 0:
             dataloader_params["persistent_workers"] = self.args.dataloader_persistent_workers
-            dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
+            if self.args.dataloader_prefetch_factor is not None:
+                dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
 
         if not isinstance(train_dataset, torch.utils.data.IterableDataset):
             dataloader_params["sampler"] = self._get_train_sampler()
@@ -385,7 +386,8 @@ class Trainer(transformers.Trainer):
 
         if self.args.dataloader_num_workers > 0:
             dataloader_params["persistent_workers"] = self.args.dataloader_persistent_workers
-            dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
+            if self.args.dataloader_prefetch_factor is not None:
+                dataloader_params["prefetch_factor"] = self.args.dataloader_prefetch_factor
 
         if not isinstance(eval_dataset, torch.utils.data.IterableDataset):
             dataloader_params["sampler"] = self._get_eval_sampler(eval_dataset)

--- a/gliner/training/trainer.py
+++ b/gliner/training/trainer.py
@@ -332,6 +332,17 @@ class Trainer(transformers.Trainer):
         return (loss, logits, labels)
 
     def get_train_dataloader(self) -> DataLoader:
+        """
+        Create and return the training DataLoader prepared by the accelerator.
+        
+        Constructs DataLoader parameters from trainer settings (batch size, collate function, number of workers, pin memory). If dataloader workers > 0, enables persistent workers and sets prefetch factor when provided. For map-style datasets, attaches the training sampler, drop-last behavior, and a worker init function that seeds workers for reproducibility.
+        
+        Returns:
+            DataLoader: An accelerator-prepared DataLoader for the training dataset.
+        
+        Raises:
+            ValueError: If no training dataset is set on the trainer.
+        """
         if self.train_dataset is None:
             raise ValueError("Trainer: training requires a train_dataset.")
 
@@ -358,6 +369,21 @@ class Trainer(transformers.Trainer):
         return self.accelerator.prepare(DataLoader(train_dataset, **dataloader_params))
 
     def get_eval_dataloader(self, eval_dataset: Optional[Union[str, Dataset]] = None) -> DataLoader:
+        """
+        Create and return a DataLoader prepared by the accelerator for evaluation.
+        
+        Parameters:
+            eval_dataset (Optional[Union[str, Dataset]]): Dataset to evaluate on or a string key selecting
+                an entry from the Trainer's `eval_dataset` mapping. If omitted, uses the Trainer's
+                `eval_dataset` attribute. Must be provided either here or on the Trainer.
+        
+        Returns:
+            DataLoader: The accelerator-prepared evaluation DataLoader configured with evaluation batch size,
+            collate function, worker settings, sampler (for map-style datasets), and optional persistent worker caching.
+        
+        Raises:
+            ValueError: If neither `eval_dataset` nor `self.eval_dataset` is available.
+        """
         if eval_dataset is None and self.eval_dataset is None:
             raise ValueError("Trainer: evaluation requires an eval_dataset.")
 

--- a/ptbr/__main__.py
+++ b/ptbr/__main__.py
@@ -101,7 +101,7 @@ def data_cmd(
                 f"(not a bi-encoder model). Use a bi-encoder model for label embeddings.",
                 err=True,
             )
-            raise typer.Exit(code=1)
+            raise typer.Exit(code=1) from None
 
         embeddings_path = Path(output_embeddings_path)
         labels_path = Path(output_labels_path)

--- a/ptbr/config_cli.py
+++ b/ptbr/config_cli.py
@@ -349,7 +349,27 @@ def _validate_cross_constraints(
     report: ValidationReport,
     raw_gliner_section: Dict[str, Any] | None = None,
 ) -> None:
-    """Check cross-field constraints that depend on method and mode."""
+    """
+    Validate cross-field constraints that depend on selected method and mode.
+    
+    Performs method-specific presence checks, enforces consistency between `method`
+    and `span_mode` (may mutate `gliner_data` to normalize `span_mode`), and adds
+    errors or warnings to `report` for incompatible or ignored fields. The function
+    does not raise exceptions; it records findings in `report`.
+    
+    Parameters:
+        gliner_data (Dict[str, Any]): Resolved GLiNER configuration values; may be
+            modified (currently `span_mode` can be changed).
+        method (str): Selected training/evaluation method (e.g., "biencoder",
+            "decoder", "relex", "span", "token").
+        full_or_lora (str): Mode selector ("full" or "lora") — included for context
+            but not directly validated by this function.
+        report (ValidationReport): Collector used to record errors and warnings.
+        raw_gliner_section (Dict[str, Any] | None): Raw YAML mapping for the
+            `gliner_config` section when available; used to determine which keys
+            were explicitly set by the user. If omitted, explicitness is inferred
+            from non-None values in `gliner_data`.
+    """
     if isinstance(raw_gliner_section, dict):
         explicit_keys = set(raw_gliner_section.keys())
     else:

--- a/ptbr/config_cli.py
+++ b/ptbr/config_cli.py
@@ -383,7 +383,7 @@ def _validate_cross_constraints(
             f"Method is 'token' but span_mode is {span_mode!r}; forcing to 'token_level'.",
         )
         gliner_data["span_mode"] = "token_level"
-    elif method in ("span", "biencoder", "decoder", "relex") and span_mode == "token_level":
+    elif method == "span" and span_mode == "token_level":
         report.add_error(
             "gliner_config.span_mode",
             f"Method is {method!r} but span_mode is 'token_level'. These select different "

--- a/ptbr/template.yaml
+++ b/ptbr/template.yaml
@@ -145,11 +145,11 @@ model:
 
   # Intermediate projection dimension after the encoder.
   # Default: 512
-  hidden_size: 768
+  hidden_size: 512
 
   # Dropout probability applied in projection / fusion layers.
   # Default: 0.4
-  dropout: 0.3
+  dropout: 0.4
 
   # ---- Encoder tuning ----
 
@@ -308,7 +308,7 @@ training:
 
   # Maximum gradient norm for clipping.
   # Default: 1.0
-  max_grad_norm: 10.0
+  max_grad_norm: 1.0
 
   # ---- Optimiser ----
 

--- a/ptbr/tests/test_train_py.py
+++ b/ptbr/tests/test_train_py.py
@@ -15,12 +15,32 @@ _UNSET = object()
 
 class _DummyModel:
     def __init__(self) -> None:
+        """
+        Initialize a lightweight dummy model for capturing training keyword arguments.
+        
+        Sets the attribute `train_kwargs` to `None`; the attribute is later populated by `train_model` when training is invoked.
+        """
         self.train_kwargs: dict | None = None
 
     def to(self, dtype=None):  # noqa: ARG002
+        """
+        No-op placeholder that provides a dtype-aware conversion API compatible with tensor modules.
+        
+        Parameters:
+            dtype: Target data type to convert the model to; accepted but ignored.
+        
+        Returns:
+            The same model instance (`self`).
+        """
         return self
 
     def train_model(self, **kwargs):
+        """
+        Capture and store training keyword arguments for later inspection.
+        
+        Parameters:
+            **kwargs: Arbitrary keyword arguments representing training parameters to record on the instance.
+        """
         self.train_kwargs = kwargs
 
 

--- a/ptbr/tests/test_train_py.py
+++ b/ptbr/tests/test_train_py.py
@@ -17,7 +17,7 @@ class _DummyModel:
     def __init__(self) -> None:
         self.train_kwargs: dict | None = None
 
-    def to(self, dtype=None):
+    def to(self, dtype=None):  # noqa: ARG002
         return self
 
     def train_model(self, **kwargs):

--- a/ptbr/tests/test_training_cli.py
+++ b/ptbr/tests/test_training_cli.py
@@ -603,6 +603,11 @@ class TestLooksLikeHfDatasetRepo:
         assert _looks_like_hf_dataset_repo("train.json") is False
 
     def test_whitespace_stripped(self) -> None:
+        """
+        Verifies that surrounding whitespace is trimmed before determining if a string looks like a Hugging Face dataset repo.
+        
+        Asserts that a trimmed HF-style repo identifier like "owner/dataset" is accepted and that a trimmed plain filename like "data.json" is rejected.
+        """
         assert _looks_like_hf_dataset_repo("  owner/dataset  ") is True
         assert _looks_like_hf_dataset_repo("  data.json  ") is False
 

--- a/ptbr/tests/test_training_cli.py
+++ b/ptbr/tests/test_training_cli.py
@@ -26,6 +26,7 @@ from ptbr.training_cli import (
     semantic_checks,
     validate_config,
     _launch_training,
+    _looks_like_hf_dataset_repo,
     check_huggingface,
 )
 
@@ -563,6 +564,47 @@ class TestCLI:
 # ------------------------------------------------------------------ #
 # Edge cases                                                           #
 # ------------------------------------------------------------------ #
+
+
+# ------------------------------------------------------------------ #
+# HF dataset repo detection                                            #
+# ------------------------------------------------------------------ #
+
+
+class TestLooksLikeHfDatasetRepo:
+    """Verify _looks_like_hf_dataset_repo distinguishes local paths from HF ids."""
+
+    @pytest.mark.parametrize("value", [
+        "data/train.json",
+        "data/Train.JSON",
+        "path/to/data.jsonl",
+        "corpus.csv",
+        "my_data.tsv",
+        "output.parquet",
+        "config.yaml",
+        "settings.yml",
+        "archive.tar.gz",
+        "data.gz",
+        "bundle.zip",
+    ])
+    def test_local_file_paths_rejected(self, value: str) -> None:
+        assert _looks_like_hf_dataset_repo(value) is False
+
+    @pytest.mark.parametrize("value", [
+        "owner/dataset",
+        "huggingface/glue",
+        "user123/my-ner-data",
+        "org/dataset_v2",
+    ])
+    def test_hf_repo_ids_accepted(self, value: str) -> None:
+        assert _looks_like_hf_dataset_repo(value) is True
+
+    def test_plain_filename_rejected(self) -> None:
+        assert _looks_like_hf_dataset_repo("train.json") is False
+
+    def test_whitespace_stripped(self) -> None:
+        assert _looks_like_hf_dataset_repo("  owner/dataset  ") is True
+        assert _looks_like_hf_dataset_repo("  data.json  ") is False
 
 
 class TestEdgeCases:

--- a/ptbr/tests/test_training_cli.py
+++ b/ptbr/tests/test_training_cli.py
@@ -922,7 +922,7 @@ class TestLaunchTrainingPropagation:
         assert captured["from_pretrained_path"] == "some/pretrained/path"
         assert captured["from_config_dict"] is None
 
-    def test_launch_training_applies_lora_if_enabled(
+    def test_launch_training_forwards_lora_config_when_enabled(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -930,13 +930,26 @@ class TestLaunchTrainingPropagation:
         cfg = self._make_cfg(tmp_path)
         cfg["lora"]["enabled"] = True
         cfg["lora"]["r"] = 16
-        self._patch_fake_runtime(monkeypatch)
+        captured = self._patch_fake_runtime(monkeypatch)
 
-        with mock.patch("ptbr.training_cli._apply_lora") as mock_apply:
-            _launch_training(cfg, tmp_path / "artifacts", resume=False, config_dir=tmp_path)
-            mock_apply.assert_called_once()
-            args, _ = mock_apply.call_args
-            assert args[1] == cfg["lora"]
+        _launch_training(cfg, tmp_path / "artifacts", resume=False, config_dir=tmp_path)
+
+        kwargs = captured["train_kwargs"]
+        assert kwargs["lora_config"] is cfg["lora"]
+
+    def test_launch_training_lora_config_none_when_disabled(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cfg = self._make_cfg(tmp_path)
+        cfg["lora"]["enabled"] = False
+        captured = self._patch_fake_runtime(monkeypatch)
+
+        _launch_training(cfg, tmp_path / "artifacts", resume=False, config_dir=tmp_path)
+
+        kwargs = captured["train_kwargs"]
+        assert kwargs["lora_config"] is None
 
     def test_launch_training_sets_env_vars(
         self,

--- a/ptbr/training_cli.py
+++ b/ptbr/training_cli.py
@@ -1188,9 +1188,8 @@ def _launch_training(
         else:
             logger.info("[CONFIG]   No training-relevant config overrides needed")
 
-    # -- LoRA --
-    if cfg.get("lora", {}).get("enabled", False):
-        _apply_lora(model, cfg["lora"])
+    # -- LoRA (forwarded to train_model) --
+    lora_cfg_for_train = cfg.get("lora") if cfg.get("lora", {}).get("enabled", False) else None
 
     # -- Load data --
     train_source, train_split, train_is_hf = _resolve_data_source(
@@ -1317,6 +1316,8 @@ def _launch_training(
         # Hub integration
         "push_to_hub": env_cfg.get("push_to_hub", False),
         "hub_model_id": env_cfg.get("hub_model_id"),
+        # LoRA
+        "lora_config": lora_cfg_for_train,
     }
 
     # -- Diagnostic logging --

--- a/ptbr/training_cli.py
+++ b/ptbr/training_cli.py
@@ -1037,11 +1037,18 @@ def _resolve_data_path(path_value: str, config_dir: Path) -> Path:
 _HF_DATASET_REPO_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*/[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 
+_LOCAL_FILE_EXTENSIONS = (
+    ".json", ".jsonl", ".csv", ".tsv", ".parquet",
+    ".yaml", ".yml", ".tar.gz", ".gz", ".zip",
+)
+
+
 def _looks_like_hf_dataset_repo(value: str) -> bool:
     """Return True when `value` looks like a HF dataset repo id `owner/name`."""
     v = value.strip()
-    # Local file extensions should never be treated as HF repos
-    if any(v.endswith(ext) for ext in (".json", ".jsonl", ".csv", ".tsv", ".parquet", ".yaml", ".yml")):
+    # Local file extensions should never be treated as HF repos.
+    # Case-insensitive check handles paths like data/Train.JSON.
+    if v.lower().endswith(_LOCAL_FILE_EXTENSIONS):
         return False
     return bool(_HF_DATASET_REPO_RE.match(v))
 

--- a/ptbr/training_cli.py
+++ b/ptbr/training_cli.py
@@ -630,7 +630,7 @@ def _check_data_paths(cfg: dict, config_dir: Path, result: ValidationResult) -> 
         val_data = val_data.strip()
         if val_data and val_data.lower() not in ("none", "null"):
             val_source, val_split, val_is_hf = _resolve_data_source(
-                val_data, config_dir, default_split="eval"
+                val_data, config_dir, default_split="validation"
             )
             if val_is_hf:
                 logger.info(
@@ -1207,7 +1207,7 @@ def _launch_training(
     val_path = cfg["data"].get("val_data_dir", "none")
     if val_path and val_path.lower() not in ("none", "null", ""):
         val_source, val_split, val_is_hf = _resolve_data_source(
-            val_path, config_dir, default_split="eval"
+            val_path, config_dir, default_split="validation"
         )
         if val_is_hf:
             logger.info(f"Loading validation data from HF dataset '{val_source}' (split='{val_split}')")
@@ -1230,9 +1230,16 @@ def _launch_training(
     # -- Resume checkpoint detection --
     resume_checkpoint = None
     if resume:
-        checkpoint_dirs = sorted(output_folder.glob("checkpoint-*"), key=lambda p: int(p.name.split("-")[-1]))
+        checkpoint_dirs = []
+        for p in output_folder.glob("checkpoint-*"):
+            try:
+                idx = int(p.name.split("-")[-1])
+            except ValueError:
+                continue
+            checkpoint_dirs.append((idx, p))
+        checkpoint_dirs.sort(key=lambda x: x[0])
         if checkpoint_dirs:
-            resume_checkpoint = str(checkpoint_dirs[-1])
+            resume_checkpoint = str(checkpoint_dirs[-1][1])
             logger.info(f"Resuming from checkpoint: {resume_checkpoint}")
 
     # -- Hub fields --

--- a/ptbr/training_cli.py
+++ b/ptbr/training_cli.py
@@ -607,7 +607,18 @@ def _check_enum(cfg: dict, result: ValidationResult, key: str, valid: set[str]) 
 
 
 def _check_data_paths(cfg: dict, config_dir: Path, result: ValidationResult) -> None:
-    """Validate dataset paths after schema/type checks and before training."""
+    """
+    Validate the configured training and validation data sources, recording any missing or invalid local paths and logging HF dataset sources.
+    
+    Checks:
+    - If `data.train_data` is a non-empty string, verifies whether it refers to a Hugging Face dataset (logs repo and split) or a local file (records an error if the file does not exist or is not a file).
+    - If `data.val_data_dir` is a non-empty string other than "none" or "null", performs the same HF-vs-local resolution and error recording for the validation source.
+    
+    Parameters:
+        cfg (dict): Resolved configuration mapping containing `data.train_data` and `data.val_data_dir`.
+        config_dir (Path): Directory used to resolve relative local data paths.
+        result (ValidationResult): Accumulator for validation errors and warnings; missing or invalid local paths are appended to `result.errors`.
+    """
     _, train_data = _deep_get(cfg, "data.train_data")
     if isinstance(train_data, str) and train_data.strip():
         train_source, train_split, train_is_hf = _resolve_data_source(
@@ -1044,7 +1055,17 @@ _LOCAL_FILE_EXTENSIONS = (
 
 
 def _looks_like_hf_dataset_repo(value: str) -> bool:
-    """Return True when `value` looks like a HF dataset repo id `owner/name`."""
+    """
+    Determine whether a string appears to be a Hugging Face dataset repository identifier in the form `owner/name`.
+    
+    This treats strings that end with common local file extensions (case-insensitive) as not being HF dataset identifiers.
+    
+    Parameters:
+        value (str): Candidate dataset source string.
+    
+    Returns:
+        bool: `True` if `value` looks like an HF dataset repo id in `owner/name` form and is not a local file path, `False` otherwise.
+    """
     v = value.strip()
     # Local file extensions should never be treated as HF repos.
     # Case-insensitive check handles paths like data/Train.JSON.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,8 @@ dependencies = [
     "accelerate>=1.12.0",
     "datasets>=4.5.0",
     "polars>=1.38.1",
+    "PyYAML>=5.0",
+    "rich>=12.0",
 ]
 
 dynamic = ["version"]

--- a/scripts/build_canonical_gliner_dataset.py
+++ b/scripts/build_canonical_gliner_dataset.py
@@ -466,11 +466,27 @@ def normalize_negative_row(
 
 
 def choose_hash_split(source: str, text: str) -> str:
+    """
+    Deterministically assigns a row to the "train" or "eval" split using a SHA-256 hash of the source and text.
+    
+    Parameters:
+        source (str): Identifier of the data source.
+        text (str): The text content used to derive the hash.
+    
+    Returns:
+        split (str): `"eval"` for approximately 10% of inputs (when the hash-based selector equals 0), `"train"` otherwise.
+    """
     digest = hashlib.sha256(f"{source}\n{text}".encode("utf-8")).hexdigest()
     return "eval" if (int(digest[:8], 16) % 10 == 0) else "train"
 
 
 def stable_sample_id(source: str, split: str, row_idx: int, text: str) -> str:
+    """
+    Produce a deterministic short sample identifier from the source, split, row index, and text.
+    
+    Returns:
+        str: A 20-character hexadecimal identifier derived from the SHA-256 digest of the concatenated inputs.
+    """
     digest = hashlib.sha256(f"{source}|{split}|{row_idx}|{text}".encode("utf-8")).hexdigest()
     return digest[:20]
 

--- a/scripts/build_canonical_gliner_dataset.py
+++ b/scripts/build_canonical_gliner_dataset.py
@@ -466,12 +466,12 @@ def normalize_negative_row(
 
 
 def choose_hash_split(source: str, text: str) -> str:
-    digest = hashlib.sha1(f"{source}\n{text}".encode("utf-8")).hexdigest()
+    digest = hashlib.sha256(f"{source}\n{text}".encode("utf-8")).hexdigest()
     return "eval" if (int(digest[:8], 16) % 10 == 0) else "train"
 
 
 def stable_sample_id(source: str, split: str, row_idx: int, text: str) -> str:
-    digest = hashlib.sha1(f"{source}|{split}|{row_idx}|{text}".encode("utf-8")).hexdigest()
+    digest = hashlib.sha256(f"{source}|{split}|{row_idx}|{text}".encode("utf-8")).hexdigest()
     return digest[:20]
 
 

--- a/scripts/colab_fuzzy_dedup_study.py
+++ b/scripts/colab_fuzzy_dedup_study.py
@@ -90,16 +90,22 @@ def ensure_nemo_deps() -> None:
     missing = []
     try:
         import torch  # noqa: F401
-    except Exception:
+    except ModuleNotFoundError:
         missing.append("torch")
+    except Exception as exc:
+        raise RuntimeError("Failed to import torch; check CUDA/driver compatibility.") from exc
     try:
         import ray  # noqa: F401
-    except Exception:
+    except ModuleNotFoundError:
         missing.append("ray")
+    except Exception as exc:
+        raise RuntimeError("Failed to import ray; check installation.") from exc
     try:
         import nemo_curator  # noqa: F401
-    except Exception:
+    except ModuleNotFoundError:
         missing.append("nemo-curator")
+    except Exception as exc:
+        raise RuntimeError("Failed to import nemo_curator; check installation.") from exc
     if missing:
         raise RuntimeError(
             "Missing required dependencies for fuzzy dedup: "
@@ -286,6 +292,11 @@ def run_single_sweep(
 
     removal_sec = None
     if run_removal:
+        if not duplicate_ids_path.exists():
+            raise RuntimeError(
+                f"Expected duplicate IDs at {duplicate_ids_path} but none were produced. "
+                "Disable --run-removal or inspect the identify stage output."
+            )
         st2 = time.time()
         removal = TextDuplicatesRemovalWorkflow(
             input_path=str(input_dir),

--- a/scripts/colab_fuzzy_dedup_study.py
+++ b/scripts/colab_fuzzy_dedup_study.py
@@ -87,6 +87,14 @@ def parse_str_values(spec: str) -> list[str]:
 
 
 def ensure_nemo_deps() -> None:
+    """
+    Verify that the Python packages required for the fuzzy dedup workflow are importable.
+    
+    Checks for `torch`, `ray`, and `nemo_curator`. If any package is not installed, raises a RuntimeError listing the missing packages and advising installation. If an import fails for reasons other than missing distribution (for example CUDA/driver issues for `torch`), raises a RuntimeError with a short diagnostic message.
+    
+    Raises:
+        RuntimeError: If one or more required packages are missing or if an import fails due to other errors (includes guidance for troubleshooting).
+    """
     missing = []
     try:
         import torch  # noqa: F401
@@ -234,6 +242,27 @@ def run_single_sweep(
     examples_per_cluster: int,
     run_removal: bool,
 ) -> dict[str, Any]:
+    """
+    Run a single fuzzy-deduplication sweep with the given configuration and persist results.
+    
+    Parameters:
+        cfg (SweepConfig): Sweep configuration for this run (range, n-gram and hashing params, blocksize).
+        output_root (Path): Root directory where run outputs and analysis will be written.
+        input_df (pd.DataFrame): Dataframe containing the input rows for the configured range; must include a `text` column.
+        io_kwargs (dict[str, Any] | None): Optional read/write kwargs passed to workflow stages (e.g., storage options); may be None.
+        seed (int): RNG seed used by the deduplication workflow.
+        num_top_clusters (int): Number of largest duplicate clusters to extract examples for.
+        examples_per_cluster (int): Number of example rows to include for each selected cluster.
+        run_removal (bool): If true, run the duplicate-removal stage using produced duplicate IDs and write a deduplicated dataset.
+    
+    Returns:
+        dict[str, Any]: Metrics summary for the run including `run_id`, `docs_total`, `duplicate_ids_to_remove`,
+        `duplicate_rate_pct`, timing fields (`identify_seconds`, `removal_seconds`), the sweep configuration fields,
+        and connected-components summary metrics.
+    
+    Raises:
+        RuntimeError: If `run_removal` is true but the duplicate IDs file expected from the identify stage does not exist.
+    """
     from nemo_curator.backends.experimental.ray_data import RayDataExecutor
     from nemo_curator.stages.deduplication.fuzzy import FuzzyDeduplicationWorkflow
     from nemo_curator.stages.deduplication.id_generator import CURATOR_DEDUP_ID_STR

--- a/scripts/push_gliner_jsonl_to_hub.py
+++ b/scripts/push_gliner_jsonl_to_hub.py
@@ -74,6 +74,18 @@ def make_features() -> Features:
 
 
 def _normalize_ner(ner: Any) -> list[dict[str, Any]]:
+    """
+    Normalize a list of NER annotations into a standardized list of dictionaries with keys `start`, `end`, and `label`.
+    
+    Parameters:
+        ner (Any): Input annotations, expected to be a list where each item is either:
+            - a list-like with at least three elements [start, end, label], or
+            - a dict with keys "start", "end", and "label".
+            Any other input type results in an empty list.
+    
+    Returns:
+        list[dict[str, Any]]: A list of normalized annotation dicts where `start` and `end` are integers and `label` is a trimmed non-empty string. Entries with missing/invalid start/end values or empty/null labels are omitted.
+    """
     out: list[dict[str, Any]] = []
     if not isinstance(ner, list):
         return out

--- a/scripts/push_gliner_jsonl_to_hub.py
+++ b/scripts/push_gliner_jsonl_to_hub.py
@@ -82,16 +82,26 @@ def _normalize_ner(ner: Any) -> list[dict[str, Any]]:
             try:
                 start = int(item[0])
                 end = int(item[1])
-                label = str(item[2])
+                label_val = item[2]
             except (TypeError, ValueError):
+                continue
+            if label_val is None:
+                continue
+            label = str(label_val).strip()
+            if not label:
                 continue
             out.append({"start": start, "end": end, "label": label})
         elif isinstance(item, dict):
             try:
                 start = int(item.get("start"))
                 end = int(item.get("end"))
-                label = str(item.get("label"))
+                label_val = item.get("label")
             except (TypeError, ValueError):
+                continue
+            if label_val is None:
+                continue
+            label = str(label_val).strip()
+            if not label:
                 continue
             out.append({"start": start, "end": end, "label": label})
     return out

--- a/scripts/rebalance_subject_split.py
+++ b/scripts/rebalance_subject_split.py
@@ -103,7 +103,10 @@ def parse_targets(raw_targets: list[str]) -> dict[str, float]:
             raise ValueError(f"Invalid --target value: {raw!r}. Expected 'label=fraction'.")
         label, frac_text = raw.split("=", 1)
         label = label.strip()
-        frac = float(frac_text.strip())
+        try:
+            frac = float(frac_text.strip())
+        except ValueError:
+            raise ValueError(f"Invalid fraction '{frac_text.strip()}' in --target: {raw!r}") from None
         if not label:
             raise ValueError(f"Invalid empty label in --target value: {raw!r}")
         if not (0.0 <= frac <= 1.0):

--- a/scripts/rebalance_subject_split.py
+++ b/scripts/rebalance_subject_split.py
@@ -97,6 +97,18 @@ def deterministic_key(sample_id: str) -> str:
 
 
 def parse_targets(raw_targets: list[str]) -> dict[str, float]:
+    """
+    Builds the target fraction mapping by applying label=fraction overrides to the default targets.
+    
+    Parameters:
+        raw_targets (list[str]): Iterable of override strings in the form "label=fraction". Each override updates or adds an entry in the returned mapping.
+    
+    Returns:
+        dict[str, float]: Mapping from label to target fraction (each value between 0.0 and 1.0 inclusive).
+    
+    Raises:
+        ValueError: If an override is malformed (missing '='), has an empty label, contains a non-numeric fraction, or if the fraction is outside the range 0.0–1.0.
+    """
     targets = dict(DEFAULT_TARGETS)
     for raw in raw_targets:
         if "=" not in raw:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import types
 # Only apply the shim when torch is NOT available; when torch is present,
 # let the real gliner package load normally so GLiNER/GLiNERConfig are accessible.
 try:
-    import torch  # noqa: F401
+    import torch
 except ImportError:
     if "gliner" not in sys.modules:
         _pkg = types.ModuleType("gliner")

--- a/tests/test_validator_integration.py
+++ b/tests/test_validator_integration.py
@@ -256,11 +256,13 @@ class TestParameterForwarding:
 
     @staticmethod
     def _extract_train_model_kwargs(tree: ast.AST) -> set[str]:
-        """Extract keyword argument names forwarded to model.train_model().
-
-        Handles both direct keyword args (``model.train_model(foo=bar)``) and
-        dict-splat patterns (``model.train_model(**train_kwargs)``) by
-        collecting keys from the dict literal assigned to the splatted variable.
+        """
+        Extracts keyword argument names forwarded to `model.train_model` calls in the AST.
+        
+        Recognizes direct keyword arguments and keys from dict literals assigned to variables that are later splatted with `**var` into the call.
+        
+        Returns:
+            set[str]: The set of keyword names passed to `train_model`.
         """
         kwargs: set[str] = set()
         # Collect keys from dict literals assigned to any variable that is

--- a/tests/test_validator_integration.py
+++ b/tests/test_validator_integration.py
@@ -277,11 +277,13 @@ class TestParameterForwarding:
                 target = node.target
                 value = node.value
             if isinstance(target, ast.Name) and isinstance(value, ast.Dict):
-                keys: set[str] = set()
-                for k in value.keys:
-                    if isinstance(k, ast.Constant) and isinstance(k.value, str):
-                        keys.add(k.value)
-                dict_var_keys[target.id] = keys
+                # Only capture the first assignment; ignore reassignments.
+                if target.id not in dict_var_keys:
+                    keys: set[str] = set()
+                    for k in value.keys:
+                        if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                            keys.add(k.value)
+                    dict_var_keys[target.id] = keys
 
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):


### PR DESCRIPTION
## Summary by Sourcery

Add optional LoRA adapter application within GLiNER training, tighten CLI/data handling, and harden utility scripts and tests.

New Features:
- Support applying a configurable PEFT LoRA adapter to the GLiNER encoder backbone directly via the train_model API and CLI, controlled by a lora_config parameter.

Bug Fixes:
- Ensure dataloader prefetch_factor is only set when provided to avoid misconfiguration with multiple workers.
- Correct validation split naming from 'eval' to 'validation' when resolving Hugging Face dataset sources in the training CLI.
- Make checkpoint resume logic robust to non-numeric checkpoint directory suffixes.
- Improve HF dataset repo detection to reliably distinguish repo IDs from local file paths using case-insensitive extension checks.
- Handle label None/whitespace cases in NER normalization when pushing GLiNER JSONL datasets to the Hub.
- Avoid overwriting previously captured config dict keys when extracting train_model kwargs in validator integration tests.
- Improve dependency detection and error reporting for fuzzy dedup study script imports, and guard duplicate-removal against missing IDs artifacts.
- Make --target parsing in the subject split rebalancing script validate fractions with clearer error messaging.
- Switch hash functions in canonical dataset building to SHA-256 for split assignment and stable IDs to reduce collision risk.

Enhancements:
- Forward LoRA configuration from the training CLI into model.train_model instead of applying it directly in the CLI, with tests covering enabled/disabled behavior.
- Introduce tests for _looks_like_hf_dataset_repo to verify correct classification of HF dataset IDs versus local paths.
- Tweak default model and training hyperparameters in ptbr/template.yaml to better reflect recommended values.
- Relax a cross-constraint in the config CLI so that only 'span' method conflicts with span_mode 'token_level'.
- Minor CLI and test cleanups including more precise typer.Exit usage and ignoring unused arguments in a dummy model.

Build:
- Add PyYAML and rich as project dependencies in pyproject.toml to support configuration and richer CLI behavior.

Tests:
- Expand training CLI tests to cover HF dataset repo detection and LoRA configuration forwarding semantics.