### PR TITLE
Fix dependency error reporting and forward LoRA config fields

### DIFF
--- a/gliner/model.py
+++ b/gliner/model.py
@@ -1017,6 +1017,9 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
                 - Optional "task_type" (str): One of "TOKEN_CLS", "SEQ_CLS", "CAUSAL_LM",
                   "SEQ_2_SEQ_LM", "FEATURE_EXTRACTION" (default "TOKEN_CLS").
                 - Optional "modules_to_save" (list[str]): Modules to keep trainable/saved.
+                - Optional "init_lora_weights" (bool): Initialize LoRA weights (default True).
+                - Optional "use_rslora" (bool): Use rank-stabilized LoRA (default False).
+                - Optional "fan_in_fan_out" (bool): Fan in/out for Conv1D layers (default False).
         
         Raises:
             ImportError: If the `peft` library is not installed.
@@ -1049,6 +1052,9 @@ class BaseGLiNER(ABC, nn.Module, PyTorchModelHubMixin):
             target_modules=lora_config["target_modules"],
             task_type=task_type,
             modules_to_save=lora_config.get("modules_to_save"),
+            init_lora_weights=lora_config.get("init_lora_weights", True),
+            use_rslora=lora_config.get("use_rslora", False),
+            fan_in_fan_out=lora_config.get("fan_in_fan_out", False),
         )
 
         try:

--- a/scripts/colab_fuzzy_dedup_study.py
+++ b/scripts/colab_fuzzy_dedup_study.py
@@ -98,20 +98,35 @@ def ensure_nemo_deps() -> None:
     missing = []
     try:
         import torch  # noqa: F401
-    except ModuleNotFoundError:
-        missing.append("torch")
+    except ModuleNotFoundError as exc:
+        if exc.name == "torch":
+            missing.append("torch")
+        else:
+            raise RuntimeError(
+                f"torch is installed but a sub-dependency is missing: {exc.name}"
+            ) from exc
     except Exception as exc:
         raise RuntimeError("Failed to import torch; check CUDA/driver compatibility.") from exc
     try:
         import ray  # noqa: F401
-    except ModuleNotFoundError:
-        missing.append("ray")
+    except ModuleNotFoundError as exc:
+        if exc.name == "ray":
+            missing.append("ray")
+        else:
+            raise RuntimeError(
+                f"ray is installed but a sub-dependency is missing: {exc.name}"
+            ) from exc
     except Exception as exc:
         raise RuntimeError("Failed to import ray; check installation.") from exc
     try:
         import nemo_curator  # noqa: F401
-    except ModuleNotFoundError:
-        missing.append("nemo-curator")
+    except ModuleNotFoundError as exc:
+        if exc.name == "nemo_curator":
+            missing.append("nemo-curator")
+        else:
+            raise RuntimeError(
+                f"nemo_curator is installed but a sub-dependency is missing: {exc.name}"
+            ) from exc
     except Exception as exc:
         raise RuntimeError("Failed to import nemo_curator; check installation.") from exc
     if missing:


### PR DESCRIPTION
Check exc.name in ModuleNotFoundError handlers to distinguish missing top-level packages from missing sub-dependencies, preventing misleading error messages during troubleshooting.

Forward init_lora_weights, use_rslora, and fan_in_fan_out from the lora_config dict to peft.LoraConfig so user-provided values from the training schema are no longer silently ignored.

https://claude.ai/code/session_012Ehf7uYk4FVJw5Jso4TX4q

## Summary by Sourcery

Improve dependency error handling and ensure LoRA configuration options are correctly forwarded to the underlying PEFT library.

Bug Fixes:
- Distinguish between missing top-level packages and missing sub-dependencies when importing torch, ray, and nemo_curator to avoid misleading installation error messages.
- Forward init_lora_weights, use_rslora, and fan_in_fan_out from the lora_config dict to peft.LoraConfig so user-specified values are no longer ignored.

Enhancements:
- Document additional optional LoRA configuration fields in the model's _apply_lora method docstring.