### PR TITLE
Refactor span handling with LongTensor and vectorized operations

### DIFF
--- a/gliner/data_processing/utils.py
+++ b/gliner/data_processing/utils.py
@@ -238,8 +238,7 @@ def prepare_span_idx(num_tokens, max_width):
 
     Example:
         >>> spans = prepare_span_idx(num_tokens=3, max_width=2)
-        >>> spans
-        [(0, 0), (0, 1), (1, 1), (1, 2), (2, 2), (2, 3)]
+        >>> spans  # tensor([[0,0],[0,1],[1,1],[1,2],[2,2],[2,3]])
         >>> # For sequence ["The", "cat", "sat"]:
         >>> # (0, 0) = "The"
         >>> # (0, 1) = "The cat"
@@ -247,6 +246,10 @@ def prepare_span_idx(num_tokens, max_width):
         >>> # (1, 2) = "cat sat"
         >>> # (2, 2) = "sat"
         >>> # (2, 3) would be invalid (beyond sequence length)
+
+    Returns:
+        torch.LongTensor of shape (num_tokens * max_width, 2) with columns [start, end].
     """
-    span_idx = [(i, i + j) for i in range(num_tokens) for j in range(max_width)]
-    return span_idx
+    starts = torch.arange(num_tokens, dtype=torch.long).unsqueeze(1).expand(-1, max_width).reshape(-1)
+    offsets = torch.arange(max_width, dtype=torch.long).unsqueeze(0).expand(num_tokens, -1).reshape(-1)
+    return torch.stack([starts, starts + offsets], dim=1)

--- a/gliner/modeling/utils.py
+++ b/gliner/modeling/utils.py
@@ -248,17 +248,12 @@ def build_entity_pairs(
     device = adj.device
     D = span_rep.shape[-1]
 
-    # Generate all possible (i, j) pairs where i != j
-    all_rows = []
-    all_cols = []
-    for i in range(E):
-        for j in range(E):
-            if i != j:
-                all_rows.append(i)
-                all_cols.append(j)
-
-    rows = torch.tensor(all_rows, device=device, dtype=torch.long)
-    cols = torch.tensor(all_cols, device=device, dtype=torch.long)
+    # Generate all possible (i, j) pairs where i != j using meshgrid
+    arange = torch.arange(E, device=device, dtype=torch.long)
+    grid_i, grid_j = torch.meshgrid(arange, arange, indexing='ij')
+    off_diag = grid_i != grid_j
+    rows = grid_i[off_diag]
+    cols = grid_j[off_diag]
 
     # For each example in batch, find pairs exceeding threshold
     batch_pair_lists: list[torch.Tensor] = []


### PR DESCRIPTION
## Summary by Sourcery

Switch span index utilities and related processing to use tensor-based representations and improve decoding efficiency and pair generation.

Bug Fixes:
- Align span label generation with tensor-based span indices to avoid mismatches between dict keys and index types.
- Handle empty span lists and candidate span tensors safely in greedy search and batch decoding.

Enhancements:
- Refactor prepare_span_idx to return a vectorized LongTensor and update all consumers and tests accordingly.
- Optimize greedy_search overlap checks by caching span tuples and using in-place sorting.
- Vectorize candidate span filtering and score/index extraction in batch decoding to reduce per-span operations and device transfers.
- Replace nested loops in build_entity_pairs with meshgrid-based off-diagonal index generation for better performance and clarity.

Documentation:
- Update prepare_span_idx documentation to reflect tensor return type and shape.

Tests:
- Update span index tests to assert tensor types, shapes, and ordering semantics instead of tuple lists.