### PR TITLE
Refactor span indexing to return tensors with dict-based lookups

### DIFF
--- a/gliner/data_processing/utils.py
+++ b/gliner/data_processing/utils.py
@@ -238,8 +238,7 @@ def prepare_span_idx(num_tokens, max_width):
 
     Example:
         >>> spans = prepare_span_idx(num_tokens=3, max_width=2)
-        >>> spans
-        [(0, 0), (0, 1), (1, 1), (1, 2), (2, 2), (2, 3)]
+        >>> spans  # tensor([[0,0],[0,1],[1,1],[1,2],[2,2],[2,3]])
         >>> # For sequence ["The", "cat", "sat"]:
         >>> # (0, 0) = "The"
         >>> # (0, 1) = "The cat"
@@ -247,6 +246,10 @@ def prepare_span_idx(num_tokens, max_width):
         >>> # (1, 2) = "cat sat"
         >>> # (2, 2) = "sat"
         >>> # (2, 3) would be invalid (beyond sequence length)
+
+    Returns:
+        torch.LongTensor of shape (num_tokens * max_width, 2) with columns [start, end].
     """
-    span_idx = [(i, i + j) for i in range(num_tokens) for j in range(max_width)]
-    return span_idx
+    starts = torch.arange(num_tokens, dtype=torch.long).unsqueeze(1).expand(-1, max_width).reshape(-1)
+    offsets = torch.arange(max_width, dtype=torch.long).unsqueeze(0).expand(num_tokens, -1).reshape(-1)
+    return torch.stack([starts, starts + offsets], dim=1)

--- a/gliner/modeling/utils.py
+++ b/gliner/modeling/utils.py
@@ -248,17 +248,12 @@ def build_entity_pairs(
     device = adj.device
     D = span_rep.shape[-1]
 
-    # Generate all possible (i, j) pairs where i != j
-    all_rows = []
-    all_cols = []
-    for i in range(E):
-        for j in range(E):
-            if i != j:
-                all_rows.append(i)
-                all_cols.append(j)
-
-    rows = torch.tensor(all_rows, device=device, dtype=torch.long)
-    cols = torch.tensor(all_cols, device=device, dtype=torch.long)
+    # Generate all possible (i, j) pairs where i != j using meshgrid
+    arange = torch.arange(E, device=device, dtype=torch.long)
+    grid_i, grid_j = torch.meshgrid(arange, arange, indexing='ij')
+    off_diag = grid_i != grid_j
+    rows = grid_i[off_diag]
+    cols = grid_j[off_diag]
 
     # For each example in batch, find pairs exceeding threshold
     batch_pair_lists: list[torch.Tensor] = []


### PR DESCRIPTION
## Summary by Sourcery

Refactor span handling to use tensor-based indices throughout decoding and data processing, improving performance and consistency while updating tests and utilities accordingly.

Bug Fixes:
- Fix span label generation and mapping to correctly handle tensor-based span indices and avoid invalid spans during decoding.
- Ensure greedy search handles empty span lists safely without errors.

Enhancements:
- Change prepare_span_idx to return a LongTensor and update its documentation and tests to reflect the tensor-based interface.
- Optimize candidate span filtering and score extraction in decoding with vectorized tensor operations to reduce per-span overhead.
- Vectorize entity pair generation in modeling utilities using meshgrid instead of Python loops for better efficiency.

Tests:
- Update span index tests to assert tensor shapes, dtypes, and values rather than list-of-tuples structures, and to check tensor-friendly behaviors across parameter combinations.